### PR TITLE
ci: add workflow to automatically add issues and PRs to FS project board

### DIFF
--- a/.github/workflows/add-issues-and-prs-to-fs-project-board.yml
+++ b/.github/workflows/add-issues-and-prs-to-fs-project-board.yml
@@ -1,0 +1,35 @@
+######################################################################################
+# READ THIS FIRST
+# This file is authored in FilOzone/github-mgmt repository and MANUALLY copied to other repos.
+# See https://github.com/FilOzone/github-mgmt/blob/master/files/workflows/add-issues-and-prs-to-fs-project-board.yml for more info.
+######################################################################################
+
+# This action adds all issues and PRs to the FS project board.
+# It is used to keep the project board up to date with the issues and PRs.
+# It is triggered by the issue and PR events.
+# It assumes a `FILOZZY_CI_ADD_TO_PROJECT` secret is set in the repo.
+# This secret should have the permissions outlined in https://github.com/actions/add-to-project?tab=readme-ov-file#creating-a-pat-and-adding-it-to-your-repository
+
+name: Add issues and PRs to FS project board
+
+on:
+  issues:
+    types:
+      - opened
+  # Using "pull_request_target" instead of "pull_request" to support PRs from forks.
+  # Workflow runs triggered on PRs from forks do not have access to secrets, so "github-token" input below would otherwise be empty.
+  # This action does not check out nor execute user code so we should be safe.
+  # We also hardcode to specific hash to ensure no unintended changes underneath us.
+  pull_request_target:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add all issues and prs to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/orgs/FilOzone/projects/14
+          github-token: ${{ secrets.FILOZZY_CI_ADD_TO_PROJECT }}


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow to automatically add newly opened issues and pull requests to the FilOzone project board (project #14)
- Workflow uses `pull_request_target` to support PRs from forks
- Based on the same workflow used in filecoin-pay-explorer repository

## Requirements
- Requires `FILOZZY_CI_ADD_TO_PROJECT` secret to be configured in the repository with appropriate permissions as outlined in the [add-to-project action documentation](https://github.com/actions/add-to-project?tab=readme-ov-file#creating-a-pat-and-adding-it-to-your-repository)

## Test plan
- [ ] Verify the workflow file is in the correct location
- [ ] Ensure the `FILOZZY_CI_ADD_TO_PROJECT` secret is configured in repository settings
- [ ] Merge the PR
- [ ] Test by creating a new issue and verify it's added to the project board
- [ ] Test by creating a new PR and verify it's added to the project board

🤖 Generated with [Claude Code](https://claude.com/claude-code)