### PR TITLE
ci: non-GPU instances

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,18 @@ jobs:
       run: cargo clippy --all-targets --all-features -- -D warnings
 
   integration-test:
-    runs-on: ["self-hosted", "linux", "x64", "12xlarge+amd"]
+    strategy:
+      matrix:
+        include:
+          - runner: ["self-hosted", "linux", "x64", "12xlarge+amd"]
+            name: "12xlarge-amd"
+          - runner: ["self-hosted", "linux", "x64", "9xlarge"]
+            name: "9xlarge"
+          - runner: ["self-hosted", "linux", "x64", "8xlarge+amd"]
+            name: "8xlarge-amd"
+      fail-fast: false
+    name: integration-test (${{ matrix.name }})
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
 
     steps:


### PR DESCRIPTION
CI job is transitioning away from `16xlarge+gpu` to non-GPU instances.

Test Type:
- Basic E2E `foc-devnet` setup with 1 curio SP (integration test)

Trials:
- Top level GH Actions run: https://github.com/FilOzone/foc-devnet/actions/runs/21510443918
-`8xlarge+amd` means `c5a.8xlarge` 32 vCPU, 64 GB RAM, AMD EPYC 7R32 @ 3.3 GHz
    - Verdict: ❌ FAIL 
    - GH Actions Run: https://github.com/FilOzone/foc-devnet/actions/runs/21510443918/job/61975929712
-`9xlarge` means `c5.9xlarge` 36 vCPU, 72 GB RAM, Intel Xeon Platinum 8124M @ 3.4 GHz
    - Verdict: ❌ FAIL 
    - GH Actions Run: https://github.com/FilOzone/foc-devnet/actions/runs/21510443918/job/61975929707
-`12xlarge+amd` means `c5a.12xlarge` 48 vCPU, 96 GB RAM, AMD EPYC 7R32 @ 3.3 GHz
    - Verdict: ❌ FAIL 
    - GH Actions Run: https://github.com/FilOzone/foc-devnet/actions/runs/21510443918/job/61975929709
