### PR TITLE
fix(ci): use PAT when filing scenario reports so project workflows run

### DIFF
--- a/.github/workflows/ci_run.yml
+++ b/.github/workflows/ci_run.yml
@@ -498,7 +498,11 @@ jobs:
       if: always() && steps.should_file.outputs.file == 'true' && inputs.enable_reporting
       uses: ipdxco/create-or-update-issue@v1
       with:
-        GITHUB_TOKEN: ${{ github.token }}
+        # We're not using `github.token` here because it won't trigger other workflows like `add-issues-to-project`.
+        # Instead, we use a PAT to trigger other workflows.
+        # This PAT has permissions to open/update issues, which is why it was used.
+        # Alternatively, we could create a more narrowly scoped PAT, but this would be another PAT to setup/manage.
+        GITHUB_TOKEN: ${{ secrets.FILOZZY_RELEASE_PLEASE_PAT_FILOZONE }}
         title: ${{ inputs.issue_title }}
         body: |
           The **${{ inputs.name }}** scenarios run **${{ steps.should_file.outputs.passed == 'true' && 'passed ✅' || 'failed ❌' }}**.


### PR DESCRIPTION
## Problem

Nightly scenario reporting (via `ci_nightly.yml` → reusable `ci_run.yml`) creates or updates GitHub issues for runs like the frontier/stability reports (similar in spirit to [foc-devnet#96](https://github.com/FilOzone/foc-devnet/issues/96)).

The **Add issues and PRs to FS project board** workflow (and other `issues: opened` automation) was not running for those issues.

Per GitHub Actions behavior, **events triggered with the default `GITHUB_TOKEN` / `github.token` do not start other workflows** (except cases such as `workflow_dispatch` / `repository_dispatch`). So `ipdxco/create-or-update-issue` using `github.token` produced issue activity that did not cascade to org/repo workflows that listen for new issues.

Specifically I want it so future issues like https://github.com/FilOzone/foc-devnet/issues/95 and https://github.com/FilOzone/foc-devnet/issues/96 show up on our project board.

## Change

- Use `secrets.FILOZZY_RELEASE_PLEASE_PAT_FILOZONE` as the token passed to `create-or-update-issue` so issue open/update behaves like normal bot/user API activity and downstream workflows can run.
- `ci_nightly.yml` and `ci_pull_request.yml` already call the reusable workflow with `secrets: inherit`; no caller changes.

### Notes from code review (inline comments in `ci_run.yml`)

- We avoid `github.token` here because it does not trigger other workflows such as add-issues-to-project-style automation.
- A PAT is used so those workflows do run.
- The chosen PAT already has permission to open/update issues; a **narrower-scoped PAT** would be possible but adds another secret to set up and manage.

## Checklist

- [ ] Confirm `FILOZZY_RELEASE_PLEASE_PAT_FILOZONE` is configured for **FilOzone/foc-localnet** (or inherited from org) with sufficient scopes to create/update issues and labels in this repo.

Made with [Cursor](https://cursor.com)