### PR TITLE
fix: use archive.apache.org for Cassandra downloads

### DIFF
--- a/scripts/setup-scenarios-prerequisites.sh
+++ b/scripts/setup-scenarios-prerequisites.sh
@@ -27,11 +27,12 @@ info()  { printf "${BLUE}ℹ${NC} %s\n" "$1"; }
 # ── Constants ────────────────────────────────────────────────
 FOUNDRY_VERSION="v1.6.0-rc1"
 PYENV_VERSION="v2.5.3"
-CASSANDRA_VERSION="5.0.6"
+CASSANDRA_VERSION="5.0.7"
+CASSANDRA_SHA256="556be693f1941aeb8ec1538fe6224cbefdca7bc3729f87ff0e24a0052eb98c33"
 PYTHON_VERSION="3.11.10"
 PYENV_ROOT="${PYENV_ROOT:-$HOME/.pyenv}"
 PYTHON_BIN="${PYENV_ROOT}/versions/${PYTHON_VERSION}/bin/python3"
-CASSANDRA_URL="https://dlcdn.apache.org/cassandra/${CASSANDRA_VERSION}/apache-cassandra-${CASSANDRA_VERSION}-bin.tar.gz"
+CASSANDRA_URL="https://archive.apache.org/dist/cassandra/${CASSANDRA_VERSION}/apache-cassandra-${CASSANDRA_VERSION}-bin.tar.gz"
 CASSANDRA_DIR="$HOME/.foc-devnet/artifacts/cassandra"
 FOUNDRY_DIR="$HOME/.foc-devnet/artifacts/foundry/bin"
 CASSANDRA_HOME="${CASSANDRA_DIR}/apache-cassandra-${CASSANDRA_VERSION}"
@@ -134,6 +135,7 @@ else
   mkdir -p "$CASSANDRA_DIR"
   TARBALL="${CASSANDRA_DIR}/apache-cassandra-${CASSANDRA_VERSION}-bin.tar.gz"
   curl -fL -o "$TARBALL" "$CASSANDRA_URL"
+  verify_checksum "$TARBALL" "$CASSANDRA_SHA256"
   tar -xzf "$TARBALL" -C "$CASSANDRA_DIR"
   if [[ -x "$CQLSH" ]]; then
     CQLSH_VERSION="$(CQLSH_PYTHON="$CUSTOM_PYTHON" "$CQLSH" --version 2>&1 || true)"


### PR DESCRIPTION
dlcdn.apache.org removes old patch versions when new ones are released,
which broke CI when 5.0.7 replaced 5.0.6. Switch to archive.apache.org
which retains all versions permanently. Bump to 5.0.7 and add SHA256
checksum verification.
