### PR TITLE
fix(lotus): disable unreleased network upgrade (UpgradeXxHeight) in devnet

### DIFF
--- a/scenarios/test_caching_subsystem.py
+++ b/scenarios/test_caching_subsystem.py
@@ -29,7 +29,7 @@ from scenarios.helpers import (
 )
 from scenarios.synapse import clone_and_build, upload_file
 
-CASSANDRA_VERSION = "5.0.6"
+CASSANDRA_VERSION = "5.0.7"
 PYTHON_VERSION = "3.11.10"
 PYENV_ROOT = Path.home() / ".pyenv"
 PYTHON_DIR = PYENV_ROOT / "versions" / PYTHON_VERSION

--- a/scripts/setup-scenarios-prerequisites.sh
+++ b/scripts/setup-scenarios-prerequisites.sh
@@ -27,11 +27,11 @@ info()  { printf "${BLUE}ℹ${NC} %s\n" "$1"; }
 # ── Constants ────────────────────────────────────────────────
 FOUNDRY_VERSION="v1.6.0-rc1"
 PYENV_VERSION="v2.5.3"
-CASSANDRA_VERSION="5.0.6"
+CASSANDRA_VERSION="5.0.7"
 PYTHON_VERSION="3.11.10"
 PYENV_ROOT="${PYENV_ROOT:-$HOME/.pyenv}"
 PYTHON_BIN="${PYENV_ROOT}/versions/${PYTHON_VERSION}/bin/python3"
-CASSANDRA_URL="https://dlcdn.apache.org/cassandra/${CASSANDRA_VERSION}/apache-cassandra-${CASSANDRA_VERSION}-bin.tar.gz"
+CASSANDRA_URL="https://archive.apache.org/dist/cassandra/${CASSANDRA_VERSION}/apache-cassandra-${CASSANDRA_VERSION}-bin.tar.gz"
 CASSANDRA_DIR="$HOME/.foc-devnet/artifacts/cassandra"
 FOUNDRY_DIR="$HOME/.foc-devnet/artifacts/foundry/bin"
 CASSANDRA_HOME="${CASSANDRA_DIR}/apache-cassandra-${CASSANDRA_VERSION}"

--- a/src/commands/start/lotus/setup.rs
+++ b/src/commands/start/lotus/setup.rs
@@ -3,6 +3,7 @@
 //! This module contains functions that prepare the environment
 //! for starting the Lotus daemon container.
 
+use super::super::lotus_utils::append_lotus_network_env;
 use super::super::step::SetupContext;
 use crate::constants::LOTUS_DOCKER_IMAGE;
 use crate::docker::containers::lotus_container_name;
@@ -135,6 +136,9 @@ pub fn build_docker_command(
 
     // Set working directory
     docker_args.extend_from_slice(&["-w".to_string(), "/data".to_string()]);
+
+    // Disable the next unreleased network upgrade (UpgradeXxHeight)
+    append_lotus_network_env(&mut docker_args);
 
     // Add image name
     docker_args.push(LOTUS_DOCKER_IMAGE.to_string());

--- a/src/commands/start/lotus_utils/mod.rs
+++ b/src/commands/start/lotus_utils/mod.rs
@@ -72,3 +72,16 @@ pub fn get_lotus_rpc_url(context: &SetupContext) -> Result<String, Box<dyn Error
         .parse()?;
     Ok(format!("http://localhost:{}/rpc/v1", lotus_api_port))
 }
+
+/// Append `-e LOTUS_XX_HEIGHT=-1` to docker args.
+///
+/// Lotus 2k devnet builds always have one upcoming network upgrade at a positive
+/// epoch height (UpgradeXxHeight, where "Xx" is the placeholder name for the next
+/// unreleased upgrade). When the chain reaches that epoch, it triggers an expensive
+/// state migration that causes transient ErrExpensiveFork errors on eth_call and
+/// estimateGas RPCs. Since the devnet should mirror current mainnet/calibnet
+/// behavior (not an unreleased future upgrade), we disable it.
+pub fn append_lotus_network_env(docker_args: &mut Vec<String>) {
+    docker_args.push("-e".to_string());
+    docker_args.push("LOTUS_XX_HEIGHT=-1".to_string());
+}


### PR DESCRIPTION
Lotus 2k builds schedule UpgradeXxHeight at epoch 200, triggering an expensive state migration that causes transient ErrExpensiveFork on eth_call/estimateGas. Set LOTUS_XX_HEIGHT=-1 on the daemon container to prevent this.

Stacked against https://github.com/FilOzone/foc-devnet/pull/98 to see if we can get it covered.