### PR TITLE
Change CI runner type from 16xlarge to 4xlarge (disk optimised)

### DIFF
--- a/.github/workflows/ci_run.yml
+++ b/.github/workflows/ci_run.yml
@@ -44,7 +44,7 @@ on:
 
 jobs:
   foc-start-test:
-    runs-on: ["self-hosted", "linux", "x64", "16xlarge+gpu"]
+    runs-on: ["self-hosted", "linux", "x64", "4xlarge+disk"]
     timeout-minutes: 100
     permissions:
       contents: read


### PR DESCRIPTION
The cluster comes up now, so I think it was the disk after all. The scenarios that are failing in this PR are also failing in the nightly.

Resolves https://github.com/FilOzone/foc-devnet/issues/24