### PR TITLE
[ci] Update GITHUB_TOKEN secret in CI workflow

### DIFF
--- a/.github/workflows/ci_run.yml
+++ b/.github/workflows/ci_run.yml
@@ -502,7 +502,7 @@ jobs:
         # Instead, we use a PAT to trigger other workflows.
         # This PAT has permissions to open/update issues, which is why it was used.
         # Alternatively, we could create a more narrowly scoped PAT, but this would be another PAT to setup/manage.
-        GITHUB_TOKEN: ${{ secrets.FILOZZY_RELEASE_PLEASE_PAT_FILOZONE }}
+        GITHUB_TOKEN: ${{ secrets.FILOZZY_RELEASE_PLEASE_PAT }}
         title: ${{ inputs.issue_title }}
         body: |
           The **${{ inputs.name }}** scenarios run **${{ steps.should_file.outputs.passed == 'true' && 'passed ✅' || 'failed ❌' }}**.


### PR DESCRIPTION
This fixes the token name used by the nightly build.