### PR TITLE
ci: Update git checkout to use specific SDK reference

### DIFF
--- a/scenarios/run.py
+++ b/scenarios/run.py
@@ -26,7 +26,7 @@ from scenarios.report import TestResult, write_report
 ORDER = [
     ("test_containers", 5),
     ("test_basic_balances", 10),
-    ("test_storage_e2e", 100),
+    ("test_storage_e2e", 200),
     ("test_caching_subsystem", 200),
 ]
 

--- a/scenarios/synapse.py
+++ b/scenarios/synapse.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from scenarios.helpers import info, run_cmd, sh
 
 SYNAPSE_SDK_REPO = "https://github.com/FilOzone/synapse-sdk/"
+SYNAPSE_SDK_REF = "8b85290ce100b25a8e431f4c6b1ea0a1eda450ff"
 
 
 def clone_and_build(tmp_dir: Path) -> Path | None:
@@ -17,7 +18,9 @@ def clone_and_build(tmp_dir: Path) -> Path | None:
     ):
         return None
     if not run_cmd(
-        ["git", "checkout", "master"], cwd=str(sdk_dir), label="checkout master HEAD"
+        ["git", "checkout", SYNAPSE_SDK_REF],
+        cwd=str(sdk_dir),
+        label="checkout last known good ref",
     ):
         return None
     sdk_commit = sh(f"git -C {sdk_dir} rev-parse HEAD")


### PR DESCRIPTION
This pins tests with synapse-sdk to https://github.com/FilOzone/synapse-sdk/commit/8b85290ce100b25a8e431f4c6b1ea0a1eda450ff (last known working commit). Should we start testing with last release + master? 

The next run with https://github.com/FilOzone/synapse-sdk/commit/4d47a35fb396e99d89e640ab62bb21cd3a345f02 was already failing. 

This gives us quite a large changeset to look through for the offender - https://github.com/FilOzone/synapse-sdk/compare/8b85290ce100b25a8e431f4c6b1ea0a1eda450ff..4d47a35fb396e99d89e640ab62bb21cd3a345f02 - but it would make sense if it was associated with https://github.com/FilOzone/synapse-sdk/pull/698 since the error we're seeing now is:

```
Error: The contract function "getClientDataSets" reverted with the following reason:
    message execution failed (exit=[33], revert reason=[none], vm error=[message failed with backtrace:
    ...
```

https://filecoinproject.slack.com/archives/C06GD1SS56Y/p1745413864023989 also seems relevant. Disclaimer: I haven't yet looked at what to change to make the latest version of synapse SDK work here.