### PR TITLE
fix: update frontier Curio branch

### DIFF
--- a/.github/workflows/ci_nightly.yml
+++ b/.github/workflows/ci_nightly.yml
@@ -34,7 +34,7 @@ jobs:
             issue_label: scenarios-run-stability
             issue_title: "FOC Devnet scenarios run report (stability)"
           - name: frontier
-            init_flags: "--curio gitbranch:pdpv0 --filecoin-services gitbranch:main"
+            init_flags: "--curio gitbranch:main --filecoin-services gitbranch:main"
             issue_label: scenarios-run-frontier
             issue_title: "FOC Devnet scenarios run report (frontier)"
     uses: ./.github/workflows/ci_run.yml


### PR DESCRIPTION
Saw that we are checking out the old pdpv0-branch in Curio while looking into https://github.com/FilOzone/foc-devnet/issues/114

## Summary
- Update the nightly frontier Curio source from `gitbranch:pdpv0` to `gitbranch:main`.
- Keep filecoin-services tracking `main` for frontier runs.

## Why
Curio PDP work has moved from the `pdpv0` branch to `main`, so the frontier nightly should follow the active branch instead of the stale PDP branch. This follows up on the investigation in #114.

## Validation
- Ran `git diff --check`.
- Confirmed no remaining `pdpv0` references in `.github`, `src`, `scenarios`, or `README.md`.
