### PR TITLE
fix: update filecoin-pin to v0.22.3

### DIFF
--- a/scenarios/test_multi_copy_upload.py
+++ b/scenarios/test_multi_copy_upload.py
@@ -76,15 +76,15 @@ _CONTENT_LENGTH_LINE_RE = re.compile(
 def patch_synapse_core_streaming_upload(npm_dir: Path) -> bool:
     """Strip Content-Length from @filoz/synapse-core's streaming upload headers.
 
-    synapse-core (as of 0.4.1, which filecoin-pin 0.20.1 resolves to) sets a
+    synapse-core 0.4.1 (which older filecoin-pin releases resolved to) set a
     Content-Length header on a body that flows through a streaming Transform.
     Node/undici rejects that as 'invalid content-length header', which
     filecoin-pin surfaces as
     'StorageContext store failed: Failed to store piece on service provider -
     Network request failed'.
 
-    TODO: drop this patch once filecoin-pin pins a synapse-core release that
-    omits Content-Length on streaming bodies (track upstream in FilOzone/synapse-sdk).
+    Keep this tolerant until the older workaround has been exercised against
+    the latest filecoin-pin release in CI.
 
     Returns True when the target file is in the desired state (whether or not
     a change was applied). Returns False only when the file is missing.
@@ -246,7 +246,7 @@ def run():
                 "pkg",
                 "set",
                 "type=module",
-                "dependencies.filecoin-pin=0.20.1",
+                "dependencies.filecoin-pin=0.22.3",
                 "dependencies.multiformats=13.4.2",
             ],
             label="pin filecoin-pin dependencies",

--- a/src/commands/start/user_setup/constants.rs
+++ b/src/commands/start/user_setup/constants.rs
@@ -12,8 +12,11 @@ pub const CONTAINER_FP_APPROVE_OPERATOR: &str = "user-fp-approve-operator";
 /// Gas limit for cast send transactions on Filecoin FEVM.
 pub const CAST_GAS_LIMIT: &str = "100000000";
 
-/// 1 USDFC expressed in the token's 18-decimal base unit.
-pub const USDFC_DEPOSIT_AMOUNT: &str = "1000000000000000000";
+/// 2 USDFC expressed in the token's 18-decimal base unit.
+///
+/// Latest filecoin-pin defaults to a two-copy upload path that can require more
+/// than 1 USDFC of locked funds before creating both data sets.
+pub const USDFC_DEPOSIT_AMOUNT: &str = "2000000000000000000";
 
 /// uint256 max value, used for unlimited operator approval allowances.
 pub const MAX_UINT256: &str =

--- a/src/commands/start/user_setup/constants.rs
+++ b/src/commands/start/user_setup/constants.rs
@@ -12,11 +12,11 @@ pub const CONTAINER_FP_APPROVE_OPERATOR: &str = "user-fp-approve-operator";
 /// Gas limit for cast send transactions on Filecoin FEVM.
 pub const CAST_GAS_LIMIT: &str = "100000000";
 
-/// 2 USDFC expressed in the token's 18-decimal base unit.
+/// 3 USDFC expressed in the token's 18-decimal base unit.
 ///
 /// Latest filecoin-pin defaults to a two-copy upload path that can require more
-/// than 1 USDFC of locked funds before creating both data sets.
-pub const USDFC_DEPOSIT_AMOUNT: &str = "2000000000000000000";
+/// than 2 USDFC of locked funds before creating both data sets.
+pub const USDFC_DEPOSIT_AMOUNT: &str = "3000000000000000000";
 
 /// uint256 max value, used for unlimited operator approval allowances.
 pub const MAX_UINT256: &str =


### PR DESCRIPTION
## Summary
- Update the `test_multi_copy_upload` scenario from `filecoin-pin@0.20.1` to `filecoin-pin@0.22.3`.
- Increase the preconfigured `USER_1` FilecoinPay deposit from `1 USDFC` to `3 USDFC`.
- Refresh the compatibility-shim comment now that the latest `filecoin-pin` resolves to a Synapse core release without the old streaming `Content-Length` behavior.

## Why
While investigating the failing FOC Devnet frontier run: https://github.com/FilOzone/foc-devnet/issues/117#issuecomment-4611276317, I noticed that the `filecoin-pin` scenario was still exercising older packaged Synapse dependencies than the source-SDK scenario. The source-SDK path had already picked up the upstream fix, but this scenario was still pinned to `filecoin-pin@0.20.1`, which resolves older `@filoz/synapse-*` packages.

`filecoin-pin@0.22.3` is the latest release and resolves:
- `@filoz/synapse-core@0.5.2`
- `@filoz/synapse-sdk@0.41.0`

Keeping this scenario on the latest `filecoin-pin` release should make failures easier to interpret and avoids debugging stale package behavior when the devnet tests are intended to exercise the current integration path.

## CI follow-up
After the version bump, CI no longer hit the previous `DataSetNotLive()` / `getDataSetListener(0)` failure in `test_multi_copy_upload`. It got further and exposed lockup requirements from the latest filecoin-pin two-copy upload path:

```text
Needs 1.1600 USDFC locked, but only 1.0000 USDFC is available.
```

A first bump to `2 USDFC` let the primary copy complete, but the secondary copy still failed because the first data set left only about `0.84 USDFC` available while the second copy also needed `1.16 USDFC` locked. This PR now raises the preconfigured deposit to `3 USDFC`, which clears the observed two-copy requirement with headroom.

## Validation
- Confirmed `filecoin-pin@0.22.3` installs and resolves `@filoz/synapse-core@0.5.2` / `@filoz/synapse-sdk@0.41.0`.
- Confirmed the expected `@filoz/synapse-core/dist/src/sp/upload-streaming.js` file still exists and no longer contains the old streaming `Content-Length` pattern.
- Ran `python3 -m py_compile scenarios/test_multi_copy_upload.py`.
- Ran `git diff --check`.
- Ran `cargo fmt --all -- --check`.
- Ran `cargo test --all-targets --all-features commands::start::user_setup -- --nocapture`.

`black` was not installed in the local environment, so I could not run the formatter check locally.

## Follow-up
We should consider adding automated release tracking for `filecoin-pin`. Since this pin currently lives inside a Python scenario rather than a package manager manifest, a small scheduled GitHub Actions workflow that opens a bump PR would keep the scenario aligned with upstream releases.