### PR TITLE
ci: unify dependency profiles across PR and nightly runs

### DIFF
--- a/.github/workflows/ci_nightly.yml
+++ b/.github/workflows/ci_nightly.yml
@@ -30,17 +30,15 @@ jobs:
       matrix:
         include:
           - name: stability
-            init_flags: "--curio latesttag:v* --filecoin-services latesttag:v*"
             issue_label: scenarios-run-stability
             issue_title: "FOC Devnet scenarios run report (stability)"
           - name: frontier
-            init_flags: "--curio gitbranch:main --filecoin-services gitbranch:main"
             issue_label: scenarios-run-frontier
             issue_title: "FOC Devnet scenarios run report (frontier)"
     uses: ./.github/workflows/ci_run.yml
     with:
       name: ${{ matrix.name }}
-      init_flags: ${{ matrix.init_flags }}
+      profile: ${{ matrix.name }}
       # Reporting is always on for scheduled runs; for manual dispatch it follows the input.
       enable_reporting: ${{ github.event_name == 'schedule' || inputs.reporting == true }}
       # On scheduled runs, such as nightly `inputs.skip_report_on_pass` is absent (empty string), so we cannot rely

--- a/.github/workflows/ci_pull_request.yml
+++ b/.github/workflows/ci_pull_request.yml
@@ -2,7 +2,7 @@
 # Runs on every pull request targeting main, and on every merge to main.
 #
 # Executes lint checks, cargo tests, and a single CI run with the default
-# config (no special init_flags). Issue reporting is disabled — that is
+# dependency profile. Issue reporting is disabled — that is
 # reserved for the nightly schedule run.
 
 name: CI (Pull Request)
@@ -58,6 +58,6 @@ jobs:
     uses: ./.github/workflows/ci_run.yml
     with:
       name: default
-      init_flags: ''
+      profile: default
       enable_reporting: false
     secrets: inherit

--- a/.github/workflows/ci_run.yml
+++ b/.github/workflows/ci_run.yml
@@ -4,8 +4,8 @@
 # Called by ci_pull_request.yml (default config, no reporting) and
 # ci_nightly.yml (stability / frontier matrix, issue reporting enabled).
 #
-# The only behavioural difference between callers is the `init_flags` input,
-# which controls which versions of Curio / filecoin-services are used.
+# The dependency profile controls the versions of compatibility-sensitive
+# server and client components used by the run.
 
 name: CI Run
 
@@ -16,11 +16,10 @@ on:
         description: 'Human-readable run name (e.g. default, stability, frontier)'
         required: true
         type: string
-      init_flags:
-        description: 'Extra flags forwarded to `foc-devnet init`'
-        required: false
+      profile:
+        description: 'Dependency profile: default, stability, or frontier'
+        required: true
         type: string
-        default: ''
       enable_reporting:
         description: 'When true, file a GitHub issue with the scenario report'
         required: false
@@ -123,22 +122,27 @@ jobs:
         rm -rf target/
         df -h
 
-    # Compute cache keys based on version info and source files
-    # - CODE_HASH: Changes when Lotus/Curio versions change (for build artifacts cache)
-    # - DOCKER_HASH: Changes when Dockerfiles change (for Docker images cache)
-    - name: "CHECK: {Compute version hashes}"
-      id: version-hashes
-      run: |   
-        # Get version output
-        VERSION_OUTPUT=$(./foc-devnet version 2>&1)
-        
-        # Compute CODE_HASH from Lotus/Curio versions only (filecoin-services contains contracts/scripts
-        # that are compiled by Foundry at deploy time, not compiled into Lotus/Curio binaries)
-        CODE_HASH=$(echo "$VERSION_OUTPUT" | grep -E 'default:code:(lotus|curio)' | sha256sum | cut -d' ' -f1)
-        echo "code-hash=$CODE_HASH" >> $GITHUB_OUTPUT
-        echo "CODE_HASH: $CODE_HASH"
-        
-        # Compute DOCKER_HASH from docker/ directory (Dockerfile changes)
+    # Dependency profile resolution queries npm release metadata.
+    - name: "EXEC: {Setup Node.js}, independent"
+      uses: actions/setup-node@v4
+      with:
+        node-version: 'lts/*'
+
+    - name: "CHECK: {Resolve dependency profile}"
+      id: dependencies
+      run: |
+        METADATA="$RUNNER_TEMP/ci-dependencies.json"
+        python3 scripts/resolve-ci-dependencies.py resolve \
+          --profile '${{ inputs.profile }}' \
+          --output "$METADATA" \
+          --github-output "$GITHUB_OUTPUT" \
+          --github-env "$GITHUB_ENV"
+
+    # Docker images do not contain Lotus/Curio binaries, so their cache identity
+    # depends only on the Docker build inputs.
+    - name: "CHECK: {Compute Docker hash}"
+      id: docker-hash
+      run: |
         DOCKER_HASH=$(find docker -type f -exec sha256sum {} \; | sort | sha256sum | cut -d' ' -f1)
         echo "docker-hash=$DOCKER_HASH" >> $GITHUB_OUTPUT
         echo "DOCKER_HASH: $DOCKER_HASH"
@@ -149,7 +153,7 @@ jobs:
       uses: actions/cache/restore@v4
       with:
         path: ~/.docker-images-cache
-        key: ${{ runner.os }}-docker-images-${{ steps.version-hashes.outputs.docker-hash }}
+        key: ${{ runner.os }}-docker-images-${{ steps.docker-hash.outputs.docker-hash }}
 
     # CACHE-DOCKER: If Docker images are cached, load them from tarballs
     - name: "EXEC: {Load Docker images}, DEP: {C-docker-images-cache}"
@@ -172,14 +176,14 @@ jobs:
       if: steps.cache-docker-images.outputs.cache-hit == 'true'
       run: |
         ./foc-devnet clean --all
-        ./foc-devnet init --no-docker-build ${{ inputs.init_flags }}
+        ./foc-devnet init --no-docker-build ${{ steps.dependencies.outputs.init-args }}
 
     # If Docker images are not cached, do full init (builds all images)
     - name: "EXEC: {Initialize without cache}, independent"
       if: steps.cache-docker-images.outputs.cache-hit != 'true'
       run: |
         ./foc-devnet clean --all
-        ./foc-devnet init ${{ inputs.init_flags }}
+        ./foc-devnet init ${{ steps.dependencies.outputs.init-args }}
 
     # CACHE-DOCKER: Save Docker images as tarballs for caching
     - name: "EXEC: {Save Docker images for cache}, DEP: {C-docker-images-cache}"
@@ -201,7 +205,17 @@ jobs:
       uses: actions/cache/save@v4
       with:
         path: ~/.docker-images-cache
-        key: ${{ runner.os }}-docker-images-${{ steps.version-hashes.outputs.docker-hash }}
+        key: ${{ runner.os }}-docker-images-${{ steps.docker-hash.outputs.docker-hash }}
+
+    # Verify the exact repositories cloned by init and derive source-based cache
+    # identities. filecoin-services is intentionally excluded because it does
+    # not contribute to the Lotus/Curio binaries.
+    - name: "CHECK: {Verify dependency checkouts}"
+      id: verified-dependencies
+      run: |
+        python3 scripts/resolve-ci-dependencies.py verify \
+          --metadata "$CI_DEPENDENCY_METADATA" \
+          --github-output "$GITHUB_OUTPUT"
 
     # CACHE-BINARIES: Try to restore previously built Lotus/Curio binaries
     - name: "CACHE_RESTORE: {C-build-artifacts-cache}"
@@ -209,7 +223,7 @@ jobs:
       uses: actions/cache/restore@v4
       with:
         path: ~/.foc-devnet/bin
-        key: ${{ runner.os }}-binaries-${{ inputs.name }}-${{ steps.version-hashes.outputs.code-hash }}
+        key: ${{ runner.os }}-binaries-${{ steps.verified-dependencies.outputs.source-hash }}
 
     - name: "EXEC: {Ensure permissions on binaries}, DEP: {C-build-artifacts-cache}"
       if: steps.cache-binaries.outputs.cache-hit == 'true'
@@ -222,9 +236,9 @@ jobs:
       uses: actions/cache/restore@v4
       with:
         path: ~/.foc-devnet/docker/volumes/cache/foc-builder
-        key: ${{ runner.os }}-foc-builder-cache-${{ inputs.name }}-${{ hashFiles('docker/**') }}-${{ hashFiles('src/config.rs') }}
+        key: ${{ runner.os }}-foc-builder-cache-${{ steps.verified-dependencies.outputs.go-cache-key }}-${{ hashFiles('docker/**') }}-${{ hashFiles('src/config.rs') }}
         restore-keys: |
-          ${{ runner.os }}-foc-builder-cache-${{ inputs.name }}-
+          ${{ runner.os }}-foc-builder-cache-${{ steps.verified-dependencies.outputs.go-cache-key }}-
 
     - name: "EXEC: {Ensure permissions}, DEP: {C-foc-builder-cache}"
       if: steps.cache-binaries.outputs.cache-hit != 'true' &&
@@ -250,7 +264,7 @@ jobs:
       uses: actions/cache/save@v4
       with:
         path: ~/.foc-devnet/docker/volumes/cache/foc-builder
-        key: ${{ runner.os }}-foc-builder-cache-${{ inputs.name }}-${{ hashFiles('docker/**') }}-${{ hashFiles('src/config.rs') }}
+        key: ${{ runner.os }}-foc-builder-cache-${{ steps.verified-dependencies.outputs.go-cache-key }}-${{ hashFiles('docker/**') }}-${{ hashFiles('src/config.rs') }}
 
     # CACHE-BINARIES: Save built Lotus/Curio binaries for future runs
     - name: "CACHE_SAVE: {C-build-artifacts-cache}"
@@ -258,7 +272,7 @@ jobs:
       uses: actions/cache/save@v4
       with:
         path: ~/.foc-devnet/bin
-        key: ${{ runner.os }}-binaries-${{ inputs.name }}-${{ steps.version-hashes.outputs.code-hash }}
+        key: ${{ runner.os }}-binaries-${{ steps.verified-dependencies.outputs.source-hash }}
 
     # Disk free-up
     - name: "EXEC: {Clean up Go modules}, DEP: {C-build-artifacts-cache}"
@@ -333,6 +347,7 @@ jobs:
     # Verify cluster is running correctly
     - name: "EXEC: {Check cluster status}, independent"
       if: always()
+      continue-on-error: true
       run: ./foc-devnet status
 
     - name: "EXEC: {List foc-* containers}, independent"
@@ -349,13 +364,6 @@ jobs:
         test -f "$DEVNET_INFO" || exit 1
         echo "✓ devnet-info.json created"
         jq '.version' "$DEVNET_INFO"
-
-    # Setup Node.js for JavaScript examples
-    - name: "EXEC: {Setup Node.js}, independent"
-      if: steps.start_cluster.outcome == 'success'
-      uses: actions/setup-node@v4
-      with:
-        node-version: 'lts/*'
 
     # Setup pnpm (required by scenario tests)
     - name: "EXEC: {Setup pnpm}, independent"
@@ -436,6 +444,15 @@ jobs:
             echo '```'
             ./foc-devnet version 2>&1 || echo "version command failed"
             echo '```'
+            echo ""
+            echo "## Resolved dependencies"
+            if [ -f "$CI_DEPENDENCY_METADATA" ]; then
+              echo '```json'
+              cat "$CI_DEPENDENCY_METADATA"
+              echo '```'
+            else
+              echo "Dependency metadata is unavailable."
+            fi
           } > "$REPORT"
         fi
 

--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -1321,3 +1321,10 @@ Reports are written to `~/.foc-devnet/state/latest/scenario_report.md`.
 
 Scenarios run automatically in CI after the devnet starts. On nightly runs (or manual dispatch with `reporting` enabled), failures automatically create a GitHub issue with a full report.
 
+CI resolves compatibility-sensitive dependencies from `ci/dependency-profiles.json`.
+Pull requests use the pinned `default` profile, while nightly `stability` runs use
+the latest final releases and nightly `frontier` runs pin current development
+branch heads to immutable commits. The resolved metadata path is exposed to
+scenarios as `CI_DEPENDENCY_METADATA`; Synapse SDK and filecoin-pin also receive
+their exact source, version/ref, and commit through `SYNAPSE_SDK_*` and
+`FILECOIN_PIN_*` environment variables.

--- a/ci/README.md
+++ b/ci/README.md
@@ -1,0 +1,162 @@
+# CI Dependency Profiles
+
+`dependency-profiles.json` is the central manifest for CI dependency selection.
+Its resolver is located in `scripts/resolve-ci-dependencies.py`.
+
+## Profiles
+
+The manifest currently supports three profiles:
+
+- `default`: used by PR CI, a known-working set of client versions.
+- `stability`: used by nightly CI to test stable releases.
+- `frontier`: used by nightly CI to test branch heads.
+
+Each component must define a selection for each profile.
+
+## Component Fields
+
+Top-level component fields:
+
+- `repository`: Git repository URL.
+- `npm_package`: npm package name, for components that are resolved through npm
+  metadata.
+- `default`, `stability`, `frontier`: profile selections.
+
+Profile selections always have a `strategy`. Some strategies require additional
+fields.
+
+### `config_default`
+
+Use the compiled `Config::default()` value and pass no runtime override to
+`foc-devnet init`.
+
+```json
+{
+  "strategy": "config_default"
+}
+```
+
+### `git_commit`
+
+Use an exact Git commit SHA.
+
+```json
+{
+  "strategy": "git_commit",
+  "commit": "fadc836e65804311aca3bd2276861acabe42313f"
+}
+```
+
+### `git_branch`
+
+Resolve a branch head to an immutable commit SHA before the run starts.
+
+```json
+{
+  "strategy": "git_branch",
+  "branch": "master"
+}
+```
+
+The resolved metadata records both the branch name and the exact commit.
+
+### `git_tag`
+
+Resolve a Git tag to an immutable commit SHA. `tag` can be an exact tag:
+
+```json
+{
+  "strategy": "git_tag",
+  "tag": "v1.2.3"
+}
+```
+
+`tag` can also be a pattern. Pattern selections choose the latest matching tag:
+
+```json
+{
+  "strategy": "git_tag",
+  "tag": "v*"
+}
+```
+
+By default, pattern selections exclude prerelease tags such as `-rc`, `-alpha`,
+`-beta`, and development tags. Set `include_prereleases` to include them:
+
+```json
+{
+  "strategy": "git_tag",
+  "tag": "v*",
+  "include_prereleases": true
+}
+```
+
+### `npm_version`
+
+Resolve an npm version, range, or dist-tag to a concrete package version.
+
+```json
+{
+  "strategy": "npm_version",
+  "version": "1.0.1"
+}
+```
+
+The `version` field can also be an npm dist-tag:
+
+```json
+{
+  "strategy": "npm_version",
+  "version": "latest"
+}
+```
+
+The resolver records the concrete package version selected at resolution time
+and npm `gitHead` when available.
+
+## Overrides
+
+Some profile selections can include an optional `overrides` object:
+
+```json
+{
+  "strategy": "npm_version",
+  "version": "1.0.1",
+  "overrides": {
+    "multiformats": "14.0.2"
+  }
+}
+```
+
+Overrides are explicit profile policy. The resolver validates that this is a
+string-to-string map and copies it into resolved metadata. It does not infer
+overrides from package metadata.
+
+Overrides are currently allowed only for:
+
+- `synapse-sdk`, because scenario setup controls its pnpm install.
+- `filecoin-pin` selections using `npm_version`, because those install into a
+  temporary npm project controlled by the scenario.
+
+Current consumers:
+
+- `synapse-sdk` writes overrides to the root `pnpm-workspace.yaml` before
+  running `pnpm install`.
+- npm-installed `filecoin-pin` writes overrides to the temporary npm
+  `package.json` used by the scenario.
+
+## Current Boundary
+
+`resolve-ci-dependencies.py` resolves metadata. It does **not** install
+components.
+
+Installation currently lives in three places (which consume the resolved
+metadata):
+
+- `foc-devnet init`: Lotus, Curio, and filecoin-services.
+- `scenarios/synapse.py`: Synapse SDK scenario dependency.
+- `scenarios/test_multi_copy_upload.py`: filecoin-pin scenario dependency.
+
+This split is intentional, but it is not necessarily the final shape. Resolution
+and installation should remain separate phases; however, installation behavior
+could become declarative and centralized.

--- a/ci/README.md
+++ b/ci/README.md
@@ -116,21 +116,27 @@ and npm `gitHead` when available.
 
 ## Overrides
 
-Some profile selections can include an optional `overrides` object:
+Some profile selections can include an optional `overrides` object. Each entry
+maps a package name to a `version` and a `reason` explaining why the override
+exists:
 
 ```json
 {
   "strategy": "git_tag",
   "tag": "synapse-sdk-v1.0.1",
   "overrides": {
-    "nanoid": "3.3.13"
+    "nanoid": {
+      "version": "3.3.13",
+      "reason": "nanoid 5.x is ESM-only and breaks the CJS build"
+    }
   }
 }
 ```
 
-Overrides are explicit profile policy. The resolver validates that this is a
-string-to-string map and copies it into resolved metadata. It does not infer
-overrides from package metadata.
+Overrides are explicit profile policy. Both `version` and `reason` are required
+non-empty strings; the resolver rejects any override missing either field, so an
+override cannot be added without documenting why. The reason is logged when the
+override is applied. The resolver does not infer overrides from package metadata.
 
 Overrides are currently allowed only for:
 

--- a/ci/README.md
+++ b/ci/README.md
@@ -120,10 +120,10 @@ Some profile selections can include an optional `overrides` object:
 
 ```json
 {
-  "strategy": "npm_version",
-  "version": "1.0.1",
+  "strategy": "git_tag",
+  "tag": "synapse-sdk-v1.0.1",
   "overrides": {
-    "multiformats": "14.0.2"
+    "nanoid": "3.3.13"
   }
 }
 ```

--- a/ci/dependency-profiles.json
+++ b/ci/dependency-profiles.json
@@ -1,0 +1,91 @@
+{
+  "schema_version": 1,
+  "components": {
+    "lotus": {
+      "repository": "https://github.com/filecoin-project/lotus.git",
+      "default": {
+        "strategy": "config_default"
+      },
+      "stability": {
+        "strategy": "git_tag",
+        "tag": "v*"
+      },
+      "frontier": {
+        "strategy": "git_branch",
+        "branch": "master"
+      }
+    },
+    "curio": {
+      "repository": "https://github.com/filecoin-project/curio.git",
+      "default": {
+        "strategy": "config_default"
+      },
+      "stability": {
+        "strategy": "git_tag",
+        "tag": "v*"
+      },
+      "frontier": {
+        "strategy": "git_branch",
+        "branch": "main"
+      }
+    },
+    "filecoin-services": {
+      "repository": "https://github.com/FilOzone/filecoin-services.git",
+      "default": {
+        "strategy": "config_default"
+      },
+      "stability": {
+        "strategy": "git_tag",
+        "tag": "v*"
+      },
+      "frontier": {
+        "strategy": "git_branch",
+        "branch": "main"
+      }
+    },
+    "synapse-sdk": {
+      "repository": "https://github.com/FilOzone/synapse-sdk.git",
+      "npm_package": "@filoz/synapse-sdk",
+      "default": {
+        "strategy": "git_commit",
+        "commit": "c18a0de03935002487ece0a99f697be490cd3eee",
+        "overrides": {
+          "nanoid": "3.3.13"
+        }
+      },
+      "stability": {
+        "strategy": "git_tag",
+        "tag": "synapse-sdk-v*",
+        "overrides": {
+          "nanoid": "3.3.13"
+        }
+      },
+      "frontier": {
+        "strategy": "git_branch",
+        "branch": "master",
+        "overrides": {
+          "nanoid": "3.3.13"
+        }
+      }
+    },
+    "filecoin-pin": {
+      "repository": "https://github.com/filecoin-project/filecoin-pin.git",
+      "npm_package": "filecoin-pin",
+      "default": {
+        "strategy": "npm_version",
+        "version": "1.0.1",
+        "overrides": {
+          "multiformats": "14.0.2"
+        }
+      },
+      "stability": {
+        "strategy": "npm_version",
+        "version": "latest"
+      },
+      "frontier": {
+        "strategy": "git_branch",
+        "branch": "master"
+      }
+    }
+  }
+}

--- a/ci/dependency-profiles.json
+++ b/ci/dependency-profiles.json
@@ -47,25 +47,16 @@
       "repository": "https://github.com/FilOzone/synapse-sdk.git",
       "npm_package": "@filoz/synapse-sdk",
       "default": {
-        "strategy": "git_commit",
-        "commit": "c18a0de03935002487ece0a99f697be490cd3eee",
-        "overrides": {
-          "nanoid": "3.3.13"
-        }
+        "strategy": "git_tag",
+        "tag": "synapse-sdk-v1.0.1"
       },
       "stability": {
         "strategy": "git_tag",
-        "tag": "synapse-sdk-v*",
-        "overrides": {
-          "nanoid": "3.3.13"
-        }
+        "tag": "synapse-sdk-v*"
       },
       "frontier": {
         "strategy": "git_branch",
-        "branch": "master",
-        "overrides": {
-          "nanoid": "3.3.13"
-        }
+        "branch": "master"
       }
     },
     "filecoin-pin": {
@@ -73,10 +64,7 @@
       "npm_package": "filecoin-pin",
       "default": {
         "strategy": "npm_version",
-        "version": "1.0.1",
-        "overrides": {
-          "multiformats": "14.0.2"
-        }
+        "version": "1.1.1"
       },
       "stability": {
         "strategy": "npm_version",

--- a/scenarios/dependencies.py
+++ b/scenarios/dependencies.py
@@ -79,8 +79,8 @@ def format_markdown_table(metadata: dict | None = None) -> str:
         overrides = value.get("overrides") or {}
         overrides_text = (
             ", ".join(
-                f"`{package}={override_version}`"
-                for package, override_version in sorted(overrides.items())
+                f"`{package}={spec['version']}`"
+                for package, spec in sorted(overrides.items())
             )
             or "-"
         )

--- a/scenarios/dependencies.py
+++ b/scenarios/dependencies.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Access resolved CI dependency metadata from scenario tests."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+
+def metadata_path() -> Path | None:
+    value = os.environ.get("CI_DEPENDENCY_METADATA")
+    return Path(value) if value else None
+
+
+def load_metadata() -> dict:
+    path = metadata_path()
+    if path is None or not path.is_file():
+        return {}
+    with path.open() as file:
+        return json.load(file)
+
+
+def component(name: str) -> dict:
+    components = load_metadata().get("components", {})
+    value = components.get(name)
+    if isinstance(value, dict):
+        return value
+
+    manifest_path = Path(__file__).parents[1] / "ci" / "dependency-profiles.json"
+    manifest = json.loads(manifest_path.read_text())
+    definition = manifest["components"].get(name)
+    if not definition:
+        raise RuntimeError(f"Dependency manifest has no {name!r} component")
+    selection = definition["default"]
+    fallback = {
+        "name": name,
+        "repository": definition["repository"],
+        "strategy": selection["strategy"],
+    }
+    if "overrides" in selection:
+        fallback["overrides"] = selection["overrides"]
+    if selection["strategy"] == "git_commit":
+        fallback.update(
+            source="git",
+            ref=selection["commit"],
+            commit=selection["commit"],
+        )
+    elif selection["strategy"] == "git_tag":
+        fallback.update(source="git", ref=selection["tag"])
+    elif selection["strategy"] == "npm_version":
+        fallback.update(
+            source="npm",
+            package=definition["npm_package"],
+            version=selection["version"],
+        )
+    else:
+        raise RuntimeError(
+            f"Local scenario fallback does not support {selection['strategy']!r}"
+        )
+    return fallback
+
+
+def format_markdown_table(metadata: dict | None = None) -> str:
+    if metadata is None:
+        metadata = load_metadata()
+    components = metadata.get("components", {})
+    if not components:
+        return "Resolved dependency metadata is unavailable."
+
+    rows = [
+        "| Dependency | Source | Version/ref | Commit | Overrides |",
+        "|---|---|---|---|---|",
+    ]
+    for name, value in components.items():
+        source = value.get("source", value.get("strategy", "-"))
+        version = value.get("version") or value.get("ref") or "-"
+        commit = value.get("commit") or "-"
+        overrides = value.get("overrides") or {}
+        overrides_text = (
+            ", ".join(
+                f"`{package}={override_version}`"
+                for package, override_version in sorted(overrides.items())
+            )
+            or "-"
+        )
+        rows.append(
+            f"| {name} | {source} | `{version}` | `{commit}` | {overrides_text} |"
+        )
+    return "\n".join(rows)

--- a/scenarios/report.py
+++ b/scenarios/report.py
@@ -1,11 +1,15 @@
 #!/usr/bin/env python3
 """Report generation and version info for scenario test results."""
 
+from __future__ import annotations
+
 import datetime
 import os
 import subprocess
 from dataclasses import dataclass
 from string import Template
+
+from scenarios.dependencies import format_markdown_table
 
 REPORT_MD = os.environ.get(
     "REPORT_FILE", os.path.expanduser("~/.foc-devnet/state/latest/scenario_report.md")
@@ -27,7 +31,7 @@ def get_version_info():
     for binary in ["./foc-devnet", "foc-devnet"]:
         try:
             result = subprocess.run(
-                [binary, "version", "--noterminal"],
+                [binary, "version", "--notty"],
                 capture_output=True,
                 text=True,
                 timeout=10,
@@ -51,6 +55,9 @@ _REPORT_TEMPLATE = Template("""
 
 ## Versions info
 $version_info
+
+## Resolved dependencies
+$dependency_table
 
 ## Tests summary
 $test_summary
@@ -100,6 +107,7 @@ def write_report(results: list[TestResult] | None = None, elapsed: int = 0):
         total_count=total,
         ci_run_link=_build_ci_run_link(),
         version_info=f"```\n{get_version_info()}\n```",
+        dependency_table=format_markdown_table(),
         test_summary=_build_test_summary(results),
     )
     with open(REPORT_MD, "w") as fh:

--- a/scenarios/synapse.py
+++ b/scenarios/synapse.py
@@ -1,31 +1,87 @@
 #!/usr/bin/env python3
 """Shared helpers for cloning, building, and uploading via synapse-sdk."""
 
+from __future__ import annotations
+
 import os
 import subprocess
 import time
+import json
 from pathlib import Path
 
+from scenarios.dependencies import component
 from scenarios.helpers import fail, info, ok, run_cmd, sh
 
 STATE_FORK_ERROR = "refusing explicit call due to state fork at epoch"
-SYNAPSE_SDK_REPO = "https://github.com/FilOzone/synapse-sdk/"
 UPLOAD_RETRY_DELAYS_SECS = (5, 10, 15, 30)
+
+
+def apply_pnpm_workspace_overrides(sdk_dir: Path, overrides: dict) -> bool:
+    if not overrides:
+        return True
+
+    workspace = sdk_dir / "pnpm-workspace.yaml"
+    if not workspace.is_file():
+        fail(f"pnpm-workspace.yaml not found at {workspace}")
+        return False
+
+    lines = workspace.read_text().splitlines()
+    updated = []
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        if line == "overrides:":
+            index += 1
+            while index < len(lines) and (
+                not lines[index] or lines[index].startswith((" ", "#"))
+            ):
+                index += 1
+            continue
+        updated.append(line)
+        index += 1
+
+    if updated and updated[-1]:
+        updated.append("")
+    updated.append("overrides:")
+    for package, version in sorted(overrides.items()):
+        updated.append(f"  {json.dumps(package)}: {json.dumps(version)}")
+
+    workspace.write_text("\n".join(updated) + "\n")
+    info(
+        "Applied pnpm workspace overrides: "
+        + ", ".join(
+            f"{package}={version}" for package, version in sorted(overrides.items())
+        )
+    )
+    return True
 
 
 def clone_and_build(tmp_dir: Path) -> Path | None:
     """Clone synapse-sdk into tmp_dir, install deps, build. Returns sdk_dir or None on failure."""
+    dependency = component("synapse-sdk")
+    repository = dependency["repository"]
+    checkout = dependency.get("commit") or dependency["ref"]
     sdk_dir = tmp_dir / "synapse-sdk"
     if not run_cmd(
-        ["git", "clone", SYNAPSE_SDK_REPO, str(sdk_dir)], label="clone synapse-sdk"
+        ["git", "clone", repository, str(sdk_dir)], label="clone synapse-sdk"
     ):
         return None
     if not run_cmd(
-        ["git", "checkout", "master"], cwd=str(sdk_dir), label="checkout master HEAD"
+        ["git", "checkout", "--detach", checkout],
+        cwd=str(sdk_dir),
+        label=f"checkout synapse-sdk {checkout}",
     ):
         return None
     sdk_commit = sh(f"git -C {sdk_dir} rev-parse HEAD")
+    expected_commit = dependency.get("commit")
+    if expected_commit and sdk_commit != expected_commit:
+        raise RuntimeError(
+            f"synapse-sdk checkout is {sdk_commit}, expected {expected_commit}"
+        )
     info(f"synapse-sdk commit: {sdk_commit}")
+    overrides = dependency.get("overrides", {})
+    if not apply_pnpm_workspace_overrides(sdk_dir, overrides):
+        return None
     if not run_cmd(["pnpm", "install"], cwd=str(sdk_dir), label="pnpm install"):
         return None
     if not run_cmd(["pnpm", "build"], cwd=str(sdk_dir), label="pnpm build"):

--- a/scenarios/synapse.py
+++ b/scenarios/synapse.py
@@ -43,16 +43,12 @@ def apply_pnpm_workspace_overrides(sdk_dir: Path, overrides: dict) -> bool:
     if updated and updated[-1]:
         updated.append("")
     updated.append("overrides:")
-    for package, version in sorted(overrides.items()):
-        updated.append(f"  {json.dumps(package)}: {json.dumps(version)}")
+    for package, spec in sorted(overrides.items()):
+        updated.append(f"  {json.dumps(package)}: {json.dumps(spec['version'])}")
 
     workspace.write_text("\n".join(updated) + "\n")
-    info(
-        "Applied pnpm workspace overrides: "
-        + ", ".join(
-            f"{package}={version}" for package, version in sorted(overrides.items())
-        )
-    )
+    for package, spec in sorted(overrides.items()):
+        info(f"pnpm override {package}={spec['version']} ({spec['reason']})")
     return True
 
 

--- a/scenarios/test_multi_copy_upload.py
+++ b/scenarios/test_multi_copy_upload.py
@@ -134,11 +134,12 @@ def setup_filecoin_pin(work_dir: Path) -> tuple[list[str], Path]:
             "type=module",
             f"dependencies.filecoin-pin={dependency['version']}",
         ]
-        for package, version in sorted(overrides.items()):
+        for package, spec in sorted(overrides.items()):
+            info(f"npm override {package}={spec['version']} ({spec['reason']})")
             package_fields.extend(
                 [
-                    f"dependencies.{package}={version}",
-                    f"overrides.{package}={version}",
+                    f"dependencies.{package}={spec['version']}",
+                    f"overrides.{package}={spec['version']}",
                 ]
             )
         run_cmd(

--- a/scenarios/test_multi_copy_upload.py
+++ b/scenarios/test_multi_copy_upload.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 """Multi-copy upload test: upload a random file via filecoin-pin against the devnet."""
 
+from __future__ import annotations
+
 import os
 import re
 import subprocess
@@ -13,6 +15,7 @@ from urllib.request import urlopen
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+from scenarios.dependencies import component
 from scenarios.helpers import (
     assert_eq,
     assert_ok,
@@ -68,13 +71,13 @@ def output_text(value) -> str:
 
 
 def run_filecoin_pin_add(
-    filecoin_pin_bin: Path,
+    filecoin_pin_command: list[str],
     upload_dir: Path,
     extra_args: list[str],
     label: str,
 ):
     cmd = [
-        str(filecoin_pin_bin),
+        *filecoin_pin_command,
         "add",
         "--network",
         "devnet",
@@ -118,6 +121,54 @@ def run_filecoin_pin_add(
         time.sleep(ADD_INTERVAL_SECS)
 
     return last_result
+
+
+def setup_filecoin_pin(work_dir: Path) -> tuple[list[str], Path]:
+    dependency = component("filecoin-pin")
+    source = dependency["source"]
+    overrides = dependency.get("overrides", {})
+
+    if source == "npm":
+        run_cmd(["npm", "init", "-y"], label="npm init", cwd=work_dir)
+        package_fields = [
+            "type=module",
+            f"dependencies.filecoin-pin={dependency['version']}",
+        ]
+        for package, version in sorted(overrides.items()):
+            package_fields.extend(
+                [
+                    f"dependencies.{package}={version}",
+                    f"overrides.{package}={version}",
+                ]
+            )
+        run_cmd(
+            ["npm", "pkg", "set", *package_fields],
+            label=f"pin filecoin-pin {dependency['version']}",
+            cwd=work_dir,
+        )
+        run_cmd(["npm", "install"], label="npm install", cwd=work_dir)
+        return [str(work_dir / "node_modules" / ".bin" / "filecoin-pin")], work_dir
+
+    if source == "git":
+        repository_dir = work_dir / "filecoin-pin"
+        run_cmd(
+            ["git", "clone", dependency["repository"], str(repository_dir)],
+            label="clone filecoin-pin",
+        )
+        run_cmd(
+            ["git", "checkout", "--detach", dependency["commit"]],
+            cwd=repository_dir,
+            label=f"checkout filecoin-pin {dependency['commit']}",
+        )
+        run_cmd(
+            ["pnpm", "install", "--frozen-lockfile"],
+            cwd=repository_dir,
+            label="pnpm install",
+        )
+        run_cmd(["pnpm", "build"], cwd=repository_dir, label="pnpm build")
+        return ["node", str(repository_dir / "dist" / "cli.js")], repository_dir
+
+    raise RuntimeError(f"Unsupported filecoin-pin source: {source}")
 
 
 def download_and_verify(
@@ -187,22 +238,7 @@ def run():
         npm_dir = Path(npm_tmp)
         download_dir = Path(download_tmp)
 
-        run_cmd(["npm", "init", "-y"], label="npm init", cwd=npm_dir)
-
-        run_cmd(
-            [
-                "npm",
-                "pkg",
-                "set",
-                "type=module",
-                "dependencies.filecoin-pin=1.0.1",
-                "dependencies.multiformats=13.4.2",
-            ],
-            label="pin filecoin-pin dependencies",
-            cwd=npm_dir,
-        )
-
-        run_cmd(["npm", "install"], label="npm install", cwd=npm_dir)
+        filecoin_pin_command, dependency_dir = setup_filecoin_pin(npm_dir)
 
         random_file = upload_dir / RAND_FILE_NAME
         info(f"Creating random file ({RAND_FILE_SIZE} bytes)")
@@ -215,10 +251,8 @@ def run():
 
         info("Running filecoin-pin multi-copy upload script against devnet")
 
-        filecoin_pin_bin = npm_dir / "node_modules" / ".bin" / "filecoin-pin"
-
         add_result = run_filecoin_pin_add(
-            filecoin_pin_bin,
+            filecoin_pin_command,
             upload_dir,
             [],
             "default multi-copy",
@@ -297,7 +331,7 @@ def run():
 
         for i, url in enumerate(root_retrieval_urls, start=1):
             file = download_dir / f"{root_cid}_{i}.bin"
-            error = download_and_verify(url, file, root_cid, npm_dir)
+            error = download_and_verify(url, file, root_cid, dependency_dir)
             if error:
                 fail(error)
                 return

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -22,16 +22,19 @@ else
   skip "cargo"
 fi
 
-if find scenarios -name '*.py' 2>/dev/null | grep -q .; then
+if find scenarios scripts -name '*.py' 2>/dev/null | grep -q .; then
   if command -v black &>/dev/null; then
     if [[ "$FIX" == "1" ]]; then
-      black scenarios/ && pass "black" || fail "black"
+      black scenarios/ scripts/ && pass "black" || fail "black"
     else
-      black --check scenarios/ && pass "black" || fail "black (run lint.sh to fix)"
+      black --check scenarios/ scripts/ && pass "black" || fail "black (run lint.sh to fix)"
     fi
   else
     skip "black (pip install black)"
   fi
 fi
+
+python3 -m unittest discover -s scripts/tests -p 'test_*.py' &&
+  pass "dependency resolver tests" || fail "dependency resolver tests"
 
 [[ $FAIL -eq 0 ]] && printf "\033[32m✓ All checks passed.\033[0m\n" || { printf "\033[31m✗ Linting failed.\033[0m\n"; exit 1; }

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -34,7 +34,11 @@ if find scenarios scripts -name '*.py' 2>/dev/null | grep -q .; then
   fi
 fi
 
-python3 -m unittest discover -s scripts/tests -p 'test_*.py' &&
-  pass "dependency resolver tests" || fail "dependency resolver tests"
+if command -v python3 &>/dev/null; then
+  python3 -m unittest discover -s scripts/tests -p 'test_*.py' &&
+    pass "dependency resolver tests" || fail "dependency resolver tests"
+else
+  skip "dependency resolver tests (python3)"
+fi
 
 [[ $FAIL -eq 0 ]] && printf "\033[32m✓ All checks passed.\033[0m\n" || { printf "\033[31m✗ Linting failed.\033[0m\n"; exit 1; }

--- a/scripts/resolve-ci-dependencies.py
+++ b/scripts/resolve-ci-dependencies.py
@@ -189,11 +189,19 @@ def npm_metadata(package: str, version: str, runner=run_command) -> dict:
 def validate_overrides(name: str, strategy: str, overrides) -> dict:
     if overrides is None:
         return {}
-    if not isinstance(overrides, dict) or not all(
-        isinstance(key, str) and isinstance(value, str)
-        for key, value in overrides.items()
-    ):
-        raise ResolutionError(f"{name} overrides must be a string map")
+    if not isinstance(overrides, dict):
+        raise ResolutionError(f"{name} overrides must be a map")
+    for package, spec in overrides.items():
+        if (
+            not isinstance(package, str)
+            or not isinstance(spec, dict)
+            or set(spec) != {"version", "reason"}
+            or not all(isinstance(spec[key], str) and spec[key] for key in spec)
+        ):
+            raise ResolutionError(
+                f"{name} override {package!r} must be an object with non-empty "
+                "string 'version' and 'reason' fields"
+            )
 
     if name == "synapse-sdk":
         return dict(sorted(overrides.items()))

--- a/scripts/resolve-ci-dependencies.py
+++ b/scripts/resolve-ci-dependencies.py
@@ -1,0 +1,380 @@
+#!/usr/bin/env python3
+"""Resolve CI dependency profiles to immutable versions and verify checkouts."""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import hashlib
+import json
+import os
+import re
+import shlex
+import subprocess
+from pathlib import Path
+
+PROFILES = {"default", "stability", "frontier"}
+INIT_COMPONENT_FLAGS = {
+    "lotus": "--lotus",
+    "curio": "--curio",
+    "filecoin-services": "--filecoin-services",
+}
+VERSION_RE = re.compile(r"^\d+(?:\.\d+)*(?:[-+][0-9A-Za-z.-]+)?$")
+STABLE_VERSION_RE = re.compile(r"^\d+(?:\.\d+)*$")
+COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+class ResolutionError(RuntimeError):
+    pass
+
+
+def run_command(command: list[str]) -> str:
+    result = subprocess.run(command, text=True, capture_output=True)
+    if result.returncode != 0:
+        details = (result.stderr or result.stdout).strip()
+        raise ResolutionError(f"{shlex.join(command)} failed: {details}")
+    return result.stdout.strip()
+
+
+def load_manifest(path: Path) -> dict:
+    try:
+        manifest = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as error:
+        raise ResolutionError(
+            f"Cannot load dependency manifest {path}: {error}"
+        ) from error
+
+    if manifest.get("schema_version") != 1:
+        raise ResolutionError("Dependency manifest schema_version must be 1")
+    components = manifest.get("components")
+    if not isinstance(components, dict):
+        raise ResolutionError("Dependency manifest must contain a components object")
+
+    required = set(INIT_COMPONENT_FLAGS) | {"synapse-sdk", "filecoin-pin"}
+    missing = sorted(required - set(components))
+    if missing:
+        raise ResolutionError(f"Dependency manifest is missing: {', '.join(missing)}")
+    return manifest
+
+
+def parse_ls_remote(output: str) -> list[tuple[str, str]]:
+    refs = []
+    for line in output.splitlines():
+        fields = line.split()
+        if len(fields) == 2:
+            refs.append((fields[0], fields[1]))
+    return refs
+
+
+def resolve_ref(repository: str, ref: str, runner=run_command) -> str:
+    refs = parse_ls_remote(runner(["git", "ls-remote", repository, ref]))
+    if not refs:
+        raise ResolutionError(f"No ref {ref} found in {repository}")
+    return refs[0][0]
+
+
+def resolve_tag(repository: str, tag: str, runner=run_command) -> str:
+    refs = parse_ls_remote(
+        runner(["git", "ls-remote", repository, f"refs/tags/{tag}*"])
+    )
+    target = f"refs/tags/{tag}"
+    exact_refs = [
+        (commit, ref) for commit, ref in refs if ref in {target, f"{target}^{{}}"}
+    ]
+    if not exact_refs:
+        raise ResolutionError(f"No tag {tag} found in {repository}")
+    peeled = next((commit for commit, ref in exact_refs if ref.endswith("^{}")), None)
+    return peeled or exact_refs[0][0]
+
+
+def tag_version(tag: str, pattern: str) -> str | None:
+    if not fnmatch.fnmatchcase(tag, pattern):
+        return None
+    star = pattern.find("*")
+    version = tag
+    if star >= 0:
+        prefix = pattern[:star]
+        suffix = pattern[star + 1 :]
+        version = tag[len(prefix) :]
+        if suffix:
+            version = version[: -len(suffix)]
+    version = version.removeprefix("v")
+    if not VERSION_RE.fullmatch(version):
+        return None
+    return version
+
+
+def stable_version(tag: str, pattern: str) -> tuple[int, ...] | None:
+    version = tag_version(tag, pattern)
+    if version is None:
+        return None
+    if not STABLE_VERSION_RE.fullmatch(version):
+        return None
+    return tuple(int(part) for part in version.split("."))
+
+
+def version_sort_key(version: str) -> tuple[tuple[int, ...], int, str]:
+    public_version = version.split("+", 1)[0]
+    numeric_text, separator, prerelease = public_version.partition("-")
+    numeric = tuple(int(part) for part in numeric_text.split("."))
+    return numeric, 0 if separator else 1, prerelease
+
+
+def select_latest_non_prerelease_tag(output: str, pattern: str) -> tuple[str, str]:
+    tag_commits = {}
+    peeled_commits = {}
+    for commit, ref in parse_ls_remote(output):
+        if not ref.startswith("refs/tags/"):
+            continue
+        tag = ref.removeprefix("refs/tags/").removesuffix("^{}")
+        if ref.endswith("^{}"):
+            peeled_commits[tag] = commit
+        else:
+            tag_commits[tag] = commit
+
+    candidates = []
+    for tag, commit in tag_commits.items():
+        version = stable_version(tag, pattern)
+        if version is not None:
+            candidates.append((version, tag, peeled_commits.get(tag, commit)))
+    if not candidates:
+        raise ResolutionError(f"No stable tags match {pattern}")
+    _, tag, commit = max(candidates)
+    return tag, commit
+
+
+def select_latest_tag(
+    output: str, pattern: str, include_prereleases: bool = False
+) -> tuple[str, str]:
+    if not include_prereleases:
+        return select_latest_non_prerelease_tag(output, pattern)
+
+    tag_commits = {}
+    peeled_commits = {}
+    for commit, ref in parse_ls_remote(output):
+        if not ref.startswith("refs/tags/"):
+            continue
+        tag = ref.removeprefix("refs/tags/").removesuffix("^{}")
+        if ref.endswith("^{}"):
+            peeled_commits[tag] = commit
+        else:
+            tag_commits[tag] = commit
+
+    candidates = []
+    for tag, commit in tag_commits.items():
+        version = tag_version(tag, pattern)
+        if version is not None:
+            candidates.append(
+                (version_sort_key(version), tag, peeled_commits.get(tag, commit))
+            )
+    if not candidates:
+        raise ResolutionError(f"No tags match {pattern}")
+    _, tag, commit = max(candidates)
+    return tag, commit
+
+
+def npm_metadata(package: str, version: str, runner=run_command) -> dict:
+    resolved_version = json.loads(
+        runner(["npm", "view", f"{package}@{version}", "version", "--json"])
+    )
+    if not resolved_version:
+        raise ResolutionError(f"npm returned no version for {package}@{version}")
+    git_head_output = runner(
+        ["npm", "view", f"{package}@{resolved_version}", "gitHead", "--json"]
+    )
+    git_head = json.loads(git_head_output) if git_head_output else ""
+    return {"version": resolved_version, "gitHead": git_head}
+
+
+def validate_overrides(name: str, strategy: str, overrides) -> dict:
+    if overrides is None:
+        return {}
+    if not isinstance(overrides, dict) or not all(
+        isinstance(key, str) and isinstance(value, str)
+        for key, value in overrides.items()
+    ):
+        raise ResolutionError(f"{name} overrides must be a string map")
+
+    if name == "synapse-sdk":
+        return dict(sorted(overrides.items()))
+    if name == "filecoin-pin" and strategy == "npm_version":
+        return dict(sorted(overrides.items()))
+    raise ResolutionError(
+        f"{name} overrides are not supported with strategy {strategy!r}"
+    )
+
+
+def resolve_component(
+    name: str, component: dict, profile: str, runner=run_command
+) -> dict:
+    try:
+        selection = component[profile]
+        strategy = selection["strategy"]
+        repository = component["repository"]
+    except KeyError as error:
+        raise ResolutionError(f"{name} is missing required field {error}") from error
+
+    resolved = {
+        "name": name,
+        "repository": repository,
+        "strategy": strategy,
+    }
+
+    if strategy == "config_default":
+        resolved["source"] = "config_default"
+    elif strategy == "git_commit":
+        commit = selection["commit"]
+        if not COMMIT_RE.fullmatch(commit):
+            raise ResolutionError(f"{name} has invalid commit SHA {commit!r}")
+        resolved.update(source="git", ref_type="commit", ref=commit, commit=commit)
+    elif strategy == "git_tag":
+        tag = selection["tag"]
+        if any(char in tag for char in "*?["):
+            include_prereleases = selection.get("include_prereleases", False)
+            if not isinstance(include_prereleases, bool):
+                raise ResolutionError(f"{name} include_prereleases must be a boolean")
+            output = runner(["git", "ls-remote", "--tags", repository, tag])
+            tag, commit = select_latest_tag(output, tag, include_prereleases)
+        else:
+            commit = resolve_tag(repository, tag, runner)
+        resolved.update(source="git", ref_type="tag", ref=tag, commit=commit)
+    elif strategy == "git_branch":
+        branch = selection["branch"]
+        commit = resolve_ref(repository, f"refs/heads/{branch}", runner)
+        resolved.update(source="git", ref_type="branch", ref=branch, commit=commit)
+    elif strategy == "npm_version":
+        requested = selection["version"]
+        data = npm_metadata(component["npm_package"], requested, runner)
+        resolved.update(
+            source="npm",
+            package=component["npm_package"],
+            version=data["version"],
+            commit=data.get("gitHead", ""),
+        )
+    else:
+        raise ResolutionError(f"Unsupported strategy {strategy!r} for {name}")
+    overrides = selection.get("overrides")
+    if overrides is not None:
+        resolved["overrides"] = validate_overrides(name, strategy, overrides)
+    return resolved
+
+
+def build_init_args(components: dict) -> list[str]:
+    args = []
+    for name, flag in INIT_COMPONENT_FLAGS.items():
+        component = components[name]
+        if component["source"] == "config_default":
+            continue
+        args.extend(
+            [
+                flag,
+                f"gitcommit:{component['repository']}:{component['commit']}",
+            ]
+        )
+    return args
+
+
+def cache_hash(components: dict) -> str:
+    values = [f"{name}:{components[name]['commit']}" for name in ("lotus", "curio")]
+    return hashlib.sha256("\n".join(values).encode()).hexdigest()
+
+
+def write_github_file(path: str | None, values: dict) -> None:
+    if not path:
+        return
+    with open(path, "a") as output:
+        for key, value in values.items():
+            output.write(f"{key}={value}\n")
+
+
+def scenario_environment(metadata_path: Path, components: dict) -> dict:
+    synapse = components["synapse-sdk"]
+    filecoin_pin = components["filecoin-pin"]
+    return {
+        "CI_DEPENDENCY_METADATA": str(metadata_path.resolve()),
+        "SYNAPSE_SDK_SOURCE": synapse["source"],
+        "SYNAPSE_SDK_REF": synapse.get("ref", ""),
+        "SYNAPSE_SDK_COMMIT": synapse.get("commit", ""),
+        "FILECOIN_PIN_SOURCE": filecoin_pin["source"],
+        "FILECOIN_PIN_VERSION": filecoin_pin.get("version", ""),
+        "FILECOIN_PIN_COMMIT": filecoin_pin.get("commit", ""),
+    }
+
+
+def resolve(args) -> None:
+    if args.profile not in PROFILES:
+        raise ResolutionError(f"Unknown profile {args.profile!r}")
+    manifest = load_manifest(args.manifest)
+    components = {
+        name: resolve_component(name, component, args.profile)
+        for name, component in manifest["components"].items()
+    }
+    metadata = {
+        "schema_version": 1,
+        "profile": args.profile,
+        "components": components,
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(metadata, indent=2, sort_keys=True) + "\n")
+
+    init_args = shlex.join(build_init_args(components))
+    write_github_file(args.github_output, {"init-args": init_args})
+    write_github_file(args.github_env, scenario_environment(args.output, components))
+    print(json.dumps(metadata, indent=2, sort_keys=True))
+
+
+def verify(args) -> None:
+    metadata = json.loads(args.metadata.read_text())
+    components = metadata["components"]
+    for name in INIT_COMPONENT_FLAGS:
+        repository_path = args.code_dir / name
+        actual = run_command(["git", "-C", str(repository_path), "rev-parse", "HEAD"])
+        expected = components[name].get("commit")
+        if expected and actual != expected:
+            raise ResolutionError(f"{name} checkout is {actual}, expected {expected}")
+        components[name]["commit"] = actual
+        components[name]["verified"] = True
+
+    args.metadata.write_text(json.dumps(metadata, indent=2, sort_keys=True) + "\n")
+    source_hash = cache_hash(components)
+    write_github_file(
+        args.github_output,
+        {"source-hash": source_hash, "go-cache-key": source_hash},
+    )
+    print(f"Verified dependency checkouts; source hash: {source_hash}")
+
+
+def parser() -> argparse.ArgumentParser:
+    root = argparse.ArgumentParser()
+    subparsers = root.add_subparsers(dest="operation", required=True)
+
+    resolve_parser = subparsers.add_parser("resolve")
+    resolve_parser.add_argument("--profile", required=True)
+    resolve_parser.add_argument(
+        "--manifest", type=Path, default=Path("ci/dependency-profiles.json")
+    )
+    resolve_parser.add_argument("--output", type=Path, required=True)
+    resolve_parser.add_argument("--github-output")
+    resolve_parser.add_argument("--github-env")
+    resolve_parser.set_defaults(handler=resolve)
+
+    verify_parser = subparsers.add_parser("verify")
+    verify_parser.add_argument("--metadata", type=Path, required=True)
+    verify_parser.add_argument(
+        "--code-dir", type=Path, default=Path.home() / ".foc-devnet" / "code"
+    )
+    verify_parser.add_argument("--github-output")
+    verify_parser.set_defaults(handler=verify)
+    return root
+
+
+def main() -> None:
+    args = parser().parse_args()
+    try:
+        args.handler(args)
+    except (ResolutionError, KeyError, json.JSONDecodeError) as error:
+        raise SystemExit(f"dependency resolution failed: {error}") from error
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test_resolve_ci_dependencies.py
+++ b/scripts/tests/test_resolve_ci_dependencies.py
@@ -151,7 +151,7 @@ class ResolverTests(unittest.TestCase):
             "default": {
                 "strategy": "npm_version",
                 "version": "1.0.1",
-                "overrides": {"multiformats": "14.0.2"},
+                "overrides": {"nanoid": {"version": "3.3.13", "reason": "test"}},
             },
         }
         runner = FakeRunner(
@@ -177,16 +177,19 @@ class ResolverTests(unittest.TestCase):
             "filecoin-pin", component, "default", runner
         )
 
-        self.assertEqual(resolved["overrides"], {"multiformats": "14.0.2"})
+        self.assertEqual(
+            resolved["overrides"],
+            {"nanoid": {"version": "3.3.13", "reason": "test"}},
+        )
 
-    def test_profile_overrides_must_be_string_map(self):
+    def test_profile_overrides_require_version_and_reason(self):
         component = {
             "repository": "https://example.test/filecoin-pin.git",
             "npm_package": "filecoin-pin",
             "default": {
                 "strategy": "npm_version",
                 "version": "1.0.1",
-                "overrides": {"multiformats": 14},
+                "overrides": {"nanoid": {"version": "3.3.13"}},
             },
         }
         runner = FakeRunner(
@@ -208,7 +211,7 @@ class ResolverTests(unittest.TestCase):
             }
         )
 
-        with self.assertRaisesRegex(resolver.ResolutionError, "overrides"):
+        with self.assertRaisesRegex(resolver.ResolutionError, "reason"):
             resolver.resolve_component("filecoin-pin", component, "default", runner)
 
     def test_overrides_are_rejected_for_core_git_components(self):
@@ -217,7 +220,7 @@ class ResolverTests(unittest.TestCase):
             "frontier": {
                 "strategy": "git_branch",
                 "branch": "master",
-                "overrides": {"nanoid": "3.3.13"},
+                "overrides": {"nanoid": {"version": "3.3.13", "reason": "test"}},
             },
         }
         runner = FakeRunner(
@@ -240,7 +243,7 @@ class ResolverTests(unittest.TestCase):
             "frontier": {
                 "strategy": "git_branch",
                 "branch": "master",
-                "overrides": {"multiformats": "14.0.2"},
+                "overrides": {"nanoid": {"version": "3.3.13", "reason": "test"}},
             },
         }
         runner = FakeRunner(

--- a/scripts/tests/test_resolve_ci_dependencies.py
+++ b/scripts/tests/test_resolve_ci_dependencies.py
@@ -1,0 +1,374 @@
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+SCRIPT = Path(__file__).parents[1] / "resolve-ci-dependencies.py"
+SPEC = importlib.util.spec_from_file_location("dependency_resolver", SCRIPT)
+resolver = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(resolver)
+
+
+class FakeRunner:
+    def __init__(self, responses):
+        self.responses = (
+            list(responses.items()) if isinstance(responses, dict) else responses
+        )
+
+    def __call__(self, command):
+        key = tuple(command)
+        for matcher, response in self.responses:
+            if callable(matcher):
+                if matcher(command):
+                    return response
+            elif key == matcher:
+                return response
+        raise AssertionError(f"Unexpected command: {command}")
+
+
+class ResolverTests(unittest.TestCase):
+    def test_latest_non_prerelease_tag_excludes_prereleases_and_annotated_refs(self):
+        output = "\n".join(
+            [
+                "aaa refs/tags/v1.9.0",
+                "bbb refs/tags/v2.0.0-rc1",
+                "ccc refs/tags/v1.10.0",
+                "ddd refs/tags/v1.10.0^{}",
+                "eee refs/tags/not-a-version",
+            ]
+        )
+        self.assertEqual(
+            resolver.select_latest_non_prerelease_tag(output, "v*"),
+            ("v1.10.0", "ddd"),
+        )
+
+    def test_prefixed_non_prerelease_tag(self):
+        output = "\n".join(
+            [
+                "aaa refs/tags/pdp/v1.2.0",
+                "bbb refs/tags/pdp/v1.11.0",
+                "ccc refs/tags/v9.0.0",
+            ]
+        )
+        self.assertEqual(
+            resolver.select_latest_non_prerelease_tag(output, "pdp/v*"),
+            ("pdp/v1.11.0", "bbb"),
+        )
+
+    def test_git_tag_pattern_can_include_prereleases(self):
+        component = {
+            "repository": "https://example.test/project.git",
+            "stability": {
+                "strategy": "git_tag",
+                "tag": "v*",
+                "include_prereleases": True,
+            },
+        }
+        runner = FakeRunner(
+            {
+                (
+                    "git",
+                    "ls-remote",
+                    "--tags",
+                    "https://example.test/project.git",
+                    "v*",
+                ): "\n".join(
+                    [
+                        "aaa refs/tags/v1.10.0",
+                        "bbb refs/tags/v2.0.0-rc1",
+                        "ccc refs/tags/not-a-version",
+                    ]
+                ),
+            }
+        )
+
+        resolved = resolver.resolve_component("project", component, "stability", runner)
+
+        self.assertEqual(resolved["ref"], "v2.0.0-rc1")
+        self.assertEqual(resolved["commit"], "bbb")
+
+    def test_unknown_profile_fails(self):
+        with tempfile.TemporaryDirectory() as directory:
+            args = type(
+                "Args",
+                (),
+                {
+                    "profile": "unknown",
+                    "manifest": Path(directory) / "manifest.json",
+                    "output": Path(directory) / "resolved.json",
+                    "github_output": None,
+                    "github_env": None,
+                },
+            )
+            with self.assertRaises(resolver.ResolutionError):
+                resolver.resolve(args)
+
+    def test_manifest_missing_component_fails(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "manifest.json"
+            path.write_text(json.dumps({"schema_version": 1, "components": {}}))
+            with self.assertRaisesRegex(resolver.ResolutionError, "missing"):
+                resolver.load_manifest(path)
+
+    def test_npm_version_resolves_dist_tag_to_npm_version(self):
+        component = {
+            "repository": "https://example.test/filecoin-pin.git",
+            "npm_package": "filecoin-pin",
+            "stability": {"strategy": "npm_version", "version": "latest"},
+        }
+        runner = FakeRunner(
+            {
+                (
+                    "npm",
+                    "view",
+                    "filecoin-pin@latest",
+                    "version",
+                    "--json",
+                ): '"1.1.1"',
+                (
+                    "npm",
+                    "view",
+                    "filecoin-pin@1.1.1",
+                    "gitHead",
+                    "--json",
+                ): '""',
+            }
+        )
+
+        resolved = resolver.resolve_component(
+            "filecoin-pin", component, "stability", runner
+        )
+
+        self.assertEqual(resolved["source"], "npm")
+        self.assertEqual(resolved["version"], "1.1.1")
+
+    def test_profile_overrides_are_copied_to_resolved_component(self):
+        component = {
+            "repository": "https://example.test/filecoin-pin.git",
+            "npm_package": "filecoin-pin",
+            "default": {
+                "strategy": "npm_version",
+                "version": "1.0.1",
+                "overrides": {"multiformats": "14.0.2"},
+            },
+        }
+        runner = FakeRunner(
+            {
+                (
+                    "npm",
+                    "view",
+                    "filecoin-pin@1.0.1",
+                    "version",
+                    "--json",
+                ): '"1.0.1"',
+                (
+                    "npm",
+                    "view",
+                    "filecoin-pin@1.0.1",
+                    "gitHead",
+                    "--json",
+                ): '""',
+            }
+        )
+
+        resolved = resolver.resolve_component(
+            "filecoin-pin", component, "default", runner
+        )
+
+        self.assertEqual(resolved["overrides"], {"multiformats": "14.0.2"})
+
+    def test_profile_overrides_must_be_string_map(self):
+        component = {
+            "repository": "https://example.test/filecoin-pin.git",
+            "npm_package": "filecoin-pin",
+            "default": {
+                "strategy": "npm_version",
+                "version": "1.0.1",
+                "overrides": {"multiformats": 14},
+            },
+        }
+        runner = FakeRunner(
+            {
+                (
+                    "npm",
+                    "view",
+                    "filecoin-pin@1.0.1",
+                    "version",
+                    "--json",
+                ): '"1.0.1"',
+                (
+                    "npm",
+                    "view",
+                    "filecoin-pin@1.0.1",
+                    "gitHead",
+                    "--json",
+                ): '""',
+            }
+        )
+
+        with self.assertRaisesRegex(resolver.ResolutionError, "overrides"):
+            resolver.resolve_component("filecoin-pin", component, "default", runner)
+
+    def test_overrides_are_rejected_for_core_git_components(self):
+        component = {
+            "repository": "https://example.test/lotus.git",
+            "frontier": {
+                "strategy": "git_branch",
+                "branch": "master",
+                "overrides": {"nanoid": "3.3.13"},
+            },
+        }
+        runner = FakeRunner(
+            {
+                (
+                    "git",
+                    "ls-remote",
+                    "https://example.test/lotus.git",
+                    "refs/heads/master",
+                ): "deadbeef refs/heads/master",
+            }
+        )
+
+        with self.assertRaisesRegex(resolver.ResolutionError, "not supported"):
+            resolver.resolve_component("lotus", component, "frontier", runner)
+
+    def test_overrides_are_rejected_for_source_built_filecoin_pin(self):
+        component = {
+            "repository": "https://example.test/filecoin-pin.git",
+            "frontier": {
+                "strategy": "git_branch",
+                "branch": "master",
+                "overrides": {"multiformats": "14.0.2"},
+            },
+        }
+        runner = FakeRunner(
+            {
+                (
+                    "git",
+                    "ls-remote",
+                    "https://example.test/filecoin-pin.git",
+                    "refs/heads/master",
+                ): "deadbeef refs/heads/master",
+            }
+        )
+
+        with self.assertRaisesRegex(resolver.ResolutionError, "not supported"):
+            resolver.resolve_component("filecoin-pin", component, "frontier", runner)
+
+    def test_frontier_branch_resolves_to_commit(self):
+        component = {
+            "repository": "https://example.test/project.git",
+            "frontier": {"strategy": "git_branch", "branch": "main"},
+        }
+        runner = FakeRunner(
+            {
+                (
+                    "git",
+                    "ls-remote",
+                    "https://example.test/project.git",
+                    "refs/heads/main",
+                ): "deadbeef refs/heads/main",
+            }
+        )
+        resolved = resolver.resolve_component("project", component, "frontier", runner)
+        self.assertEqual(resolved["commit"], "deadbeef")
+
+    def test_git_commit_strategy_uses_exact_sha_without_resolution(self):
+        commit = "fadc836e65804311aca3bd2276861acabe42313f"
+        component = {
+            "repository": "https://example.test/synapse.git",
+            "default": {"strategy": "git_commit", "commit": commit},
+        }
+        resolved = resolver.resolve_component(
+            "synapse-sdk", component, "default", FakeRunner({})
+        )
+        self.assertEqual(resolved["ref_type"], "commit")
+        self.assertEqual(resolved["ref"], commit)
+        self.assertEqual(resolved["commit"], commit)
+
+    def test_git_commit_strategy_rejects_non_sha(self):
+        component = {
+            "repository": "https://example.test/synapse.git",
+            "default": {"strategy": "git_commit", "commit": "master"},
+        }
+        with self.assertRaisesRegex(resolver.ResolutionError, "invalid commit SHA"):
+            resolver.resolve_component(
+                "synapse-sdk", component, "default", FakeRunner({})
+            )
+
+    def test_init_args_skip_config_defaults_and_pin_other_sources(self):
+        components = {
+            "lotus": {"source": "config_default"},
+            "curio": {
+                "source": "git",
+                "repository": "https://example.test/curio.git",
+                "commit": "abc",
+            },
+            "filecoin-services": {
+                "source": "git",
+                "repository": "https://example.test/services.git",
+                "commit": "def",
+            },
+        }
+        self.assertEqual(
+            resolver.build_init_args(components),
+            [
+                "--curio",
+                "gitcommit:https://example.test/curio.git:abc",
+                "--filecoin-services",
+                "gitcommit:https://example.test/services.git:def",
+            ],
+        )
+
+    def test_cache_hash_depends_only_on_lotus_and_curio_commits(self):
+        base = {
+            "lotus": {"commit": "aaa"},
+            "curio": {"commit": "bbb"},
+            "filecoin-services": {"commit": "ccc"},
+        }
+        first = resolver.cache_hash(base)
+        base["filecoin-services"]["commit"] = "changed"
+        self.assertEqual(first, resolver.cache_hash(base))
+        base["curio"]["commit"] = "changed"
+        self.assertNotEqual(first, resolver.cache_hash(base))
+
+    @patch.object(resolver, "run_command")
+    def test_verify_records_checkouts_and_writes_cache_key(self, run_command):
+        commits = {
+            "lotus": "aaa",
+            "curio": "bbb",
+            "filecoin-services": "ccc",
+        }
+        run_command.side_effect = lambda command: commits[Path(command[2]).name]
+        metadata = {
+            "schema_version": 1,
+            "profile": "default",
+            "components": {name: {"source": "config_default"} for name in commits},
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            directory = Path(directory)
+            metadata_path = directory / "metadata.json"
+            output_path = directory / "output"
+            metadata_path.write_text(json.dumps(metadata))
+            args = type(
+                "Args",
+                (),
+                {
+                    "metadata": metadata_path,
+                    "code_dir": directory / "code",
+                    "github_output": str(output_path),
+                },
+            )
+            resolver.verify(args)
+            verified = json.loads(metadata_path.read_text())
+            outputs = output_path.read_text()
+
+        self.assertEqual(verified["components"]["lotus"]["commit"], "aaa")
+        self.assertTrue(verified["components"]["curio"]["verified"])
+        self.assertIn("source-hash=", outputs)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_scenario_dependencies.py
+++ b/scripts/tests/test_scenario_dependencies.py
@@ -21,13 +21,12 @@ class ScenarioDependencyTests(unittest.TestCase):
                     "source": "git",
                     "version": "0.41.0",
                     "commit": "bbb",
-                    "overrides": {"nanoid": "3.3.13"},
+                    "overrides": {"nanoid": {"version": "3.3.13", "reason": "test"}},
                 },
                 "filecoin-pin": {
                     "source": "npm",
                     "version": "1.0.1",
                     "commit": "ccc",
-                    "overrides": {"multiformats": "14.0.2"},
                 },
             }
         }
@@ -37,11 +36,9 @@ class ScenarioDependencyTests(unittest.TestCase):
             "synapse-sdk",
             "filecoin-pin",
             "nanoid",
-            "multiformats",
             "aaa",
             "1.0.1",
             "3.3.13",
-            "14.0.2",
         ):
             self.assertIn(expected, table)
 
@@ -53,7 +50,7 @@ class ScenarioDependencyTests(unittest.TestCase):
             "repository": "https://example.test/synapse.git",
             "ref": "sdk-v1.0.0",
             "commit": "deadbeef",
-            "overrides": {"nanoid": "3.3.13"},
+            "overrides": {"nanoid": {"version": "3.3.13", "reason": "test"}},
         },
     )
     def test_synapse_checkout_uses_resolved_commit(self, _component, run_cmd, _sh):
@@ -86,7 +83,7 @@ class ScenarioDependencyTests(unittest.TestCase):
         return_value={
             "source": "npm",
             "version": "1.0.1",
-            "overrides": {"multiformats": "14.0.2"},
+            "overrides": {"nanoid": {"version": "3.3.13", "reason": "test"}},
         },
     )
     def test_filecoin_pin_npm_install_path(self, _component, run_cmd):
@@ -99,11 +96,11 @@ class ScenarioDependencyTests(unittest.TestCase):
             run_cmd.call_args_list[1].args[0],
         )
         self.assertIn(
-            "dependencies.multiformats=14.0.2",
+            "dependencies.nanoid=3.3.13",
             run_cmd.call_args_list[1].args[0],
         )
         self.assertIn(
-            "overrides.multiformats=14.0.2",
+            "overrides.nanoid=3.3.13",
             run_cmd.call_args_list[1].args[0],
         )
 

--- a/scripts/tests/test_scenario_dependencies.py
+++ b/scripts/tests/test_scenario_dependencies.py
@@ -1,0 +1,133 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from scenarios.dependencies import format_markdown_table
+from scenarios.synapse import clone_and_build
+from scenarios.test_multi_copy_upload import setup_filecoin_pin
+
+
+class ScenarioDependencyTests(unittest.TestCase):
+    def test_dependency_table_contains_all_resolved_components(self):
+        metadata = {
+            "components": {
+                "lotus": {
+                    "source": "git",
+                    "ref": "v1.2.3",
+                    "commit": "aaa",
+                },
+                "synapse-sdk": {
+                    "source": "git",
+                    "version": "0.41.0",
+                    "commit": "bbb",
+                    "overrides": {"nanoid": "3.3.13"},
+                },
+                "filecoin-pin": {
+                    "source": "npm",
+                    "version": "1.0.1",
+                    "commit": "ccc",
+                    "overrides": {"multiformats": "14.0.2"},
+                },
+            }
+        }
+        table = format_markdown_table(metadata)
+        for expected in (
+            "lotus",
+            "synapse-sdk",
+            "filecoin-pin",
+            "nanoid",
+            "multiformats",
+            "aaa",
+            "1.0.1",
+            "3.3.13",
+            "14.0.2",
+        ):
+            self.assertIn(expected, table)
+
+    @patch("scenarios.synapse.sh", return_value="deadbeef")
+    @patch("scenarios.synapse.run_cmd", return_value=True)
+    @patch(
+        "scenarios.synapse.component",
+        return_value={
+            "repository": "https://example.test/synapse.git",
+            "ref": "sdk-v1.0.0",
+            "commit": "deadbeef",
+            "overrides": {"nanoid": "3.3.13"},
+        },
+    )
+    def test_synapse_checkout_uses_resolved_commit(self, _component, run_cmd, _sh):
+        def fake_run_cmd(command, **_kwargs):
+            if command[:2] == ["git", "clone"]:
+                sdk_dir = Path(command[3])
+                sdk_dir.mkdir(parents=True)
+                (sdk_dir / "pnpm-workspace.yaml").write_text(
+                    "packages:\n  - packages/*\n"
+                )
+            return True
+
+        run_cmd.side_effect = fake_run_cmd
+        with tempfile.TemporaryDirectory() as directory:
+            clone_and_build(Path(directory))
+            workspace = Path(directory) / "synapse-sdk" / "pnpm-workspace.yaml"
+            workspace_text = workspace.read_text()
+        checkout = run_cmd.call_args_list[1]
+        self.assertEqual(
+            checkout.args[0],
+            ["git", "checkout", "--detach", "deadbeef"],
+        )
+        commands = [call.args[0] for call in run_cmd.call_args_list]
+        self.assertNotIn(["pnpm", "pkg", "set"], [command[:3] for command in commands])
+        self.assertIn('  "nanoid": "3.3.13"', workspace_text)
+
+    @patch("scenarios.test_multi_copy_upload.run_cmd", return_value=True)
+    @patch(
+        "scenarios.test_multi_copy_upload.component",
+        return_value={
+            "source": "npm",
+            "version": "1.0.1",
+            "overrides": {"multiformats": "14.0.2"},
+        },
+    )
+    def test_filecoin_pin_npm_install_path(self, _component, run_cmd):
+        with tempfile.TemporaryDirectory() as directory:
+            command, dependency_dir = setup_filecoin_pin(Path(directory))
+        self.assertTrue(command[0].endswith("node_modules/.bin/filecoin-pin"))
+        self.assertEqual(dependency_dir, Path(directory))
+        self.assertIn(
+            "dependencies.filecoin-pin=1.0.1",
+            run_cmd.call_args_list[1].args[0],
+        )
+        self.assertIn(
+            "dependencies.multiformats=14.0.2",
+            run_cmd.call_args_list[1].args[0],
+        )
+        self.assertIn(
+            "overrides.multiformats=14.0.2",
+            run_cmd.call_args_list[1].args[0],
+        )
+
+    @patch("scenarios.test_multi_copy_upload.run_cmd", return_value=True)
+    @patch(
+        "scenarios.test_multi_copy_upload.component",
+        return_value={
+            "source": "git",
+            "repository": "https://example.test/filecoin-pin.git",
+            "commit": "deadbeef",
+        },
+    )
+    def test_filecoin_pin_frontier_build_path(self, _component, run_cmd):
+        with tempfile.TemporaryDirectory() as directory:
+            command, dependency_dir = setup_filecoin_pin(Path(directory))
+        self.assertEqual(command[0], "node")
+        self.assertTrue(command[1].endswith("filecoin-pin/dist/cli.js"))
+        self.assertTrue(str(dependency_dir).endswith("filecoin-pin"))
+        commands = [call.args[0] for call in run_cmd.call_args_list]
+        self.assertIn(["git", "checkout", "--detach", "deadbeef"], commands)
+        self.assertNotIn(["pnpm", "pkg", "set"], [command[:3] for command in commands])
+        self.assertIn(["pnpm", "install", "--frozen-lockfile"], commands)
+        self.assertIn(["pnpm", "build"], commands)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR expands the version combinations we test foc-devnet with.

The general setup is to test in 3 modes/profiles:
- default: pinned version numbers of all dependencies (in this context, that means: Lotus, Curio, filecoin-services, Synapse SDK, and filecoin-pin)
- stability: latest releases of the dependencies (used in nightly builds)
- frontier: latest commits of the dependencies (used in nightly builds)

To track all of this, I introduce a JSON dependency manifest ([`ci/dependency-profiles.json`](https://github.com/FilOzone/foc-devnet/blob/0c37543bae7efc280e5df4047e22336835e294c4/ci/dependency-profiles.json)) which describes these profiles: what version to use, where to get it from (git vs npm), etc. 

I also fixed the dependency-version-dependent cache setup and updated the test scenarios to use the dependencies tracked by the manifest.

## Testing

- [x] Run the test scenarios on a PR on this branch - https://github.com/FilOzone/foc-devnet/actions/runs/28303973070/job/83856996242?pr=128
  - [x] Success
- [x] Run the nightly tests from this branch - https://github.com/FilOzone/foc-devnet/actions/runs/28303344010
  - [x] Success

## TODO

- [x] When installing filecoin-pin, pin multiformats to the version that synapse-sdk accepts.
