### PR TITLE
fix: update stability and frontier dependencies

### DIFF
--- a/.github/workflows/ci_nightly.yml
+++ b/.github/workflows/ci_nightly.yml
@@ -30,7 +30,7 @@ jobs:
       matrix:
         include:
           - name: stability
-            init_flags: "--curio latesttag:pdp/v* --filecoin-services latesttag:v*"
+            init_flags: "--curio gittag:v1.28.2 --filecoin-services latesttag:v*"
             issue_label: scenarios-run-stability
             issue_title: "FOC Devnet scenarios run report (stability)"
           - name: frontier

--- a/scenarios/test_multi_copy_upload.py
+++ b/scenarios/test_multi_copy_upload.py
@@ -246,7 +246,7 @@ def run():
                 "pkg",
                 "set",
                 "type=module",
-                "dependencies.filecoin-pin=0.22.3",
+                "dependencies.filecoin-pin=1.0.1",
                 "dependencies.multiformats=13.4.2",
             ],
             label="pin filecoin-pin dependencies",

--- a/src/config.rs
+++ b/src/config.rs
@@ -285,15 +285,15 @@ impl Default for Config {
             port_range_count: 100,
             lotus: Location::GitTag {
                 url: "https://github.com/filecoin-project/lotus.git".to_string(),
-                tag: "v1.35.0".to_string(),
+                tag: "v1.36.0".to_string(),
             },
-            curio: Location::GitCommit {
+            curio: Location::GitTag {
                 url: "https://github.com/filecoin-project/curio.git".to_string(),
-                commit: "60f77a618eee24cd3482be5fea545e01f26052a4".to_string(),
+                tag: "v1.28.2".to_string(),
             },
             filecoin_services: Location::GitTag {
                 url: "https://github.com/FilOzone/filecoin-services.git".to_string(),
-                tag: "v1.2.0".to_string(),
+                tag: "v1.3.0".to_string(),
             },
             multicall3: Location::GitTag {
                 url: "https://github.com/mds1/multicall3.git".to_string(),


### PR DESCRIPTION
## Summary
- Update the multi-copy scenario to install filecoin-pin@1.0.1.
- Update default dependency pins to Lotus v1.36.0, Curio v1.28.2, and filecoin-services v1.3.0.
- Pin the stability scenario workflow to Curio v1.28.2 instead of the stale latesttag:pdp/v* selector.

## Verification
- Required PR CI is green: https://github.com/FilOzone/foc-devnet/actions/runs/27809239421
  - lint: pass
  - cargo-test: pass
  - default foc-devnet scenario run: pass
- Manual nightly stability validation passed 5/5: https://github.com/FilOzone/foc-devnet/actions/runs/27809240509/job/82295635141
- Previous manual frontier validation passed 5/5 with filecoin-pin@1.0.1: https://github.com/FilOzone/foc-devnet/actions/runs/27765742646

Closes #117
Closes #124