### PR TITLE
fix: use latest Curio tag for stability runs

### DIFF
--- a/.github/workflows/ci_nightly.yml
+++ b/.github/workflows/ci_nightly.yml
@@ -30,7 +30,7 @@ jobs:
       matrix:
         include:
           - name: stability
-            init_flags: "--curio gittag:v1.28.2 --filecoin-services latesttag:v*"
+            init_flags: "--curio latesttag:v* --filecoin-services latesttag:v*"
             issue_label: scenarios-run-stability
             issue_title: "FOC Devnet scenarios run report (stability)"
           - name: frontier


### PR DESCRIPTION
## Summary
- Update the nightly stability run to use `--curio latesttag:v*`.
- Follow up on the review comment from merged PR #131: https://github.com/FilOzone/foc-devnet/pull/131#discussion_r3453070194

## Verification
- `git diff --check`