### PR TITLE
fix: scenario balance cast call diagnostics

### DIFF
--- a/scenarios/helpers.py
+++ b/scenarios/helpers.py
@@ -86,10 +86,15 @@ def assert_ok(cmd, msg):
 
 
 def sh(cmd):
-    """Run cmd in a shell and return stdout stripped, or '' on error."""
-    return subprocess.run(
-        cmd, shell=True, text=True, capture_output=True
-    ).stdout.strip()
+    """Run cmd in a shell and return stdout stripped, or fail with command output."""
+    result = subprocess.run(cmd, shell=True, text=True, capture_output=True)
+    stdout = result.stdout.strip()
+    stderr = result.stderr.strip()
+    if result.returncode == 0:
+        return stdout
+
+    details = stderr or stdout or "no output"
+    fail(f"shell command failed (exit={result.returncode}): {cmd} ({details})")
 
 
 def run_cmd(

--- a/scenarios/test_basic_balances.py
+++ b/scenarios/test_basic_balances.py
@@ -21,7 +21,8 @@ def run():
         fil_wei = sh(f"{CAST} balance {user_addr} --rpc-url {lotus_rpc}")
         assert_gt(fil_wei, 0, f"{name} FIL balance > 0")
         usdfc_raw = sh(
-            f"{CAST} call {usdfc_addr} 'balanceOf(address)(uint256)' {user_addr} --rpc-url {lotus_rpc}"
+            f"{CAST} call {usdfc_addr} 'balanceOf(address)(uint256)' {user_addr} "
+            f"--from {user_addr} --rpc-url {lotus_rpc}"
         )
         usdfc_wei = "".join(c for c in usdfc_raw if c.isdigit())
         assert_gt(usdfc_wei, 0, f"{name} USDFC balance > 0")


### PR DESCRIPTION
## Summary
- Run the USDFC `cast call` from the user address being checked so Lotus/FEVM does not have to evaluate the read from Foundry's default zero address.
- Make the shared scenario `sh()` helper fail with stderr/stdout details when a shell command exits nonzero.

## Root Cause
The stability run in #134 did not show a real USDFC funding failure. Later viem/Synapse checks in the same run saw USER_1's USDFC balance. The failing Python scenario used `cast call` through a helper that discarded stderr and returned empty stdout on command failure, collapsing the useful error into `not an int: ''`.

Refs #134