### PR TITLE
chore(ci): remove renovate dependency dashboard feature

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
+  "extends": ["config:recommended", ":disableDependencyDashboard"],
   "enabledManagers": ["custom.regex"],
   "schedule": ["before 4am on monday"],
   "customManagers": [


### PR DESCRIPTION
This disables the use of an issue to manage the process, https://github.com/FilOzone/foc-devnet/issues/144, I don't think we have a good use for this for our dependencies here since we own them all and don't need the additional features like abandonment-detection.