### PR TITLE
fix(scenarios): scope source builds to required workspaces

### DIFF
--- a/scenarios/synapse.py
+++ b/scenarios/synapse.py
@@ -78,9 +78,28 @@ def clone_and_build(tmp_dir: Path) -> Path | None:
     overrides = dependency.get("overrides", {})
     if not apply_pnpm_workspace_overrides(sdk_dir, overrides):
         return None
-    if not run_cmd(["pnpm", "install"], cwd=str(sdk_dir), label="pnpm install"):
+    # Install/build only what the e2e example needs, skipping the unrelated
+    # playground, docs and react workspaces.
+    if not run_cmd(
+        ["pnpm", "install", "--filter", "utils..."],
+        cwd=str(sdk_dir),
+        label="pnpm install",
+    ):
         return None
-    if not run_cmd(["pnpm", "build"], cwd=str(sdk_dir), label="pnpm build"):
+    if not run_cmd(
+        [
+            "pnpm",
+            "-r",
+            "--filter",
+            "@filoz/synapse-core",
+            "--filter",
+            "@filoz/synapse-sdk",
+            "run",
+            "build",
+        ],
+        cwd=str(sdk_dir),
+        label="pnpm build",
+    ):
         return None
     return sdk_dir
 

--- a/scenarios/test_multi_copy_upload.py
+++ b/scenarios/test_multi_copy_upload.py
@@ -161,8 +161,9 @@ def setup_filecoin_pin(work_dir: Path) -> tuple[list[str], Path]:
             cwd=repository_dir,
             label=f"checkout filecoin-pin {dependency['commit']}",
         )
+        # Only filecoin-pin itself is needed; skip the upload-action workspace.
         run_cmd(
-            ["pnpm", "install", "--frozen-lockfile"],
+            ["pnpm", "install", "--frozen-lockfile", "--filter", "filecoin-pin..."],
             cwd=repository_dir,
             label="pnpm install",
         )

--- a/scripts/tests/test_scenario_dependencies.py
+++ b/scripts/tests/test_scenario_dependencies.py
@@ -122,7 +122,10 @@ class ScenarioDependencyTests(unittest.TestCase):
         commands = [call.args[0] for call in run_cmd.call_args_list]
         self.assertIn(["git", "checkout", "--detach", "deadbeef"], commands)
         self.assertNotIn(["pnpm", "pkg", "set"], [command[:3] for command in commands])
-        self.assertIn(["pnpm", "install", "--frozen-lockfile"], commands)
+        self.assertIn(
+            ["pnpm", "install", "--frozen-lockfile", "--filter", "filecoin-pin..."],
+            commands,
+        )
         self.assertIn(["pnpm", "build"], commands)
 
 


### PR DESCRIPTION
Addressing the problems experienced here https://github.com/FilOzone/foc-devnet/issues/138 and other places .. which come from synapse-sdk being a massive bucket of dependencies, most of which we don't care about - the playground and react and docs stuff we don't care about. So this narrows it down a little to what we need to avoid some of the mess that comes from managing such a complex dependency tree.