### PR TITLE
ci: install pnpm 11.12 directly with npm

### DIFF
--- a/.github/workflows/ci_run.yml
+++ b/.github/workflows/ci_run.yml
@@ -368,12 +368,12 @@ jobs:
     # Setup pnpm (required by scenario tests)
     - name: "EXEC: {Setup pnpm}, independent"
       if: steps.start_cluster.outcome == 'success'
-      uses: pnpm/action-setup@v6
-      with:
-        version: 11.12.0
-        # The regular pnpm 11.7.0 bootstrap cannot self-update to 11.12.0.
-        # Use @pnpm/exe until the upstream self-update fix is released.
-        standalone: true
+      # Bypass pnpm/action-setup's broken 11.7.0 -> 11.12.0 self-update and
+      # the incomplete @pnpm/exe 11.12.0 platform packages. Node is set up
+      # above, so install the regular Node-based pnpm package directly.
+      run: |
+        npm install --global pnpm@11.12.0
+        test "$(pnpm --version)" = "11.12.0"
 
     # Validate schema using zod
     - name: "CHECK: {Validate devnet-info.json schema}"

--- a/.github/workflows/ci_run.yml
+++ b/.github/workflows/ci_run.yml
@@ -368,6 +368,7 @@ jobs:
     # Setup pnpm (required by scenario tests)
     - name: "EXEC: {Setup pnpm}, independent"
       if: steps.start_cluster.outcome == 'success'
+      # TEMPORARY work-around pending solution to https://github.com/pnpm/action-setup/issues/276.
       # Bypass pnpm/action-setup's broken 11.7.0 -> 11.12.0 self-update and
       # the incomplete @pnpm/exe 11.12.0 platform packages. Node is set up
       # above, so install the regular Node-based pnpm package directly.

--- a/.github/workflows/ci_run.yml
+++ b/.github/workflows/ci_run.yml
@@ -370,7 +370,10 @@ jobs:
       if: steps.start_cluster.outcome == 'success'
       uses: pnpm/action-setup@v6
       with:
-        version: latest
+        version: 11.12.0
+        # The regular pnpm 11.7.0 bootstrap cannot self-update to 11.12.0.
+        # Use @pnpm/exe until the upstream self-update fix is released.
+        standalone: true
 
     # Validate schema using zod
     - name: "CHECK: {Validate devnet-info.json schema}"


### PR DESCRIPTION
## Summary

- install the regular Node-based pnpm 11.12.0 package directly with npm
- assert that the active pnpm version is exactly 11.12.0
- bypass both broken pnpm/action-setup self-update paths

## Why

The stability job in [run 29227598125](https://github.com/FilOzone/foc-devnet/actions/runs/29227598125) started the devnet successfully, then failed before scenario execution while pnpm/action-setup@v6 tried to self-update its pnpm 11.7.0 bootstrap to 11.12.0.

The initial standalone workaround also proved unsuitable: pnpm setup completed, but the published @pnpm/exe 11.12.0 platform package lacked its executable, causing scenario pnpm installs to fail with `@pnpm/exe/pnpm: 1: This: not found`.

Node.js 24 is already configured earlier in the workflow, so installing the regular `pnpm@11.12.0` npm package avoids both upstream failures while keeping CI on the current release.

Upstream references:

- [pnpm self-update issue](https://github.com/pnpm/pnpm/issues/12959)
- [pending self-update fix](https://github.com/pnpm/pnpm/pull/12961)
- [incomplete 11.12.0 standalone packages](https://github.com/pnpm/pnpm/issues/12955)

Fixes #149.
Fixes #150.

## Impact

Nightly stability and frontier jobs can proceed through pnpm setup and execute scenarios with pnpm 11.12.0. The version remains explicit, so future releases do not alter CI without review.

## Validation

- workflow YAML parses successfully
- regular `pnpm@11.12.0` package reports version 11.12.0
- [PR CI run 29231938057](https://github.com/FilOzone/foc-devnet/actions/runs/29231938057) passed:
  - lint: passed
  - cargo tests: passed
  - devnet scenario job: passed
  - scenarios: 5 passed, 0 failed
  - storage E2E and caching subsystem both passed
