### PR TITLE
ci: restore pnpm action setup

### DIFF
--- a/.github/workflows/ci_run.yml
+++ b/.github/workflows/ci_run.yml
@@ -368,13 +368,9 @@ jobs:
     # Setup pnpm (required by scenario tests)
     - name: "EXEC: {Setup pnpm}, independent"
       if: steps.start_cluster.outcome == 'success'
-      # TEMPORARY work-around pending solution to https://github.com/pnpm/action-setup/issues/276.
-      # Bypass pnpm/action-setup's broken 11.7.0 -> 11.12.0 self-update and
-      # the incomplete @pnpm/exe 11.12.0 platform packages. Node is set up
-      # above, so install the regular Node-based pnpm package directly.
-      run: |
-        npm install --global pnpm@11.12.0
-        test "$(pnpm --version)" = "11.12.0"
+      uses: pnpm/action-setup@v6
+      with:
+        version: 11.13.1
 
     # Validate schema using zod
     - name: "CHECK: {Validate devnet-info.json schema}"

--- a/.github/workflows/ci_run.yml
+++ b/.github/workflows/ci_run.yml
@@ -370,7 +370,7 @@ jobs:
       if: steps.start_cluster.outcome == 'success'
       uses: pnpm/action-setup@v6
       with:
-        version: 11.13.1
+        version: latest
 
     # Validate schema using zod
     - name: "CHECK: {Validate devnet-info.json schema}"


### PR DESCRIPTION
## Summary

- replace the temporary global npm installation with `pnpm/action-setup@v6`
- restore `version: latest` so CI tracks the current pnpm release
- remove the workaround comments and manual version assertion

## Why

The workflow moved to `npm install --global pnpm@11.12.0` after both pnpm/action-setup's self-update path and the 11.12.0 standalone artifacts failed.

[pnpm/action-setup#276](https://github.com/pnpm/action-setup/issues/276) confirms that the self-update failure is resolved in pnpm 11.13.0. The standalone platform packages were still incomplete in 11.13.0; [pnpm/pnpm#12955](https://github.com/pnpm/pnpm/issues/12955) confirms 11.13.1 as the repaired release. With both upstream prerequisites now shipped, the workflow can return to the maintained setup action and its previous current-release tracking behavior.

Fixes #152.
